### PR TITLE
Extra size() to SIZEOF() macro conversions

### DIFF
--- a/kauai/src/ft.cpp
+++ b/kauai/src/ft.cpp
@@ -91,7 +91,7 @@ ACR _rgacr[] = {kacrBlack,   kacrBlue,   kacrGreen, kacrCyan,  kacrRed,
                 kacrMagenta, kacrYellow, kacrWhite, kacrClear, kacrInvert};
 achar *_rgszColors[] = {PszLit("bla"), PszLit("blu"), PszLit("gre"), PszLit("cya"), PszLit("red"),
                         PszLit("mag"), PszLit("yel"), PszLit("whi"), PszLit("cle"), PszLit("inv")};
-const long _cacr = size(_rgacr) / size(_rgacr[0]);
+const long _cacr = SIZEOF(_rgacr) / SIZEOF(_rgacr[0]);
 
 RTCLASS(APP)
 
@@ -853,7 +853,7 @@ bool APP::FCmdNewTestWnd(PCMD pcmd)
             goto LFail;
     }
 
-    pcmd->pgg->GetRgb(2, 0, size(long), &lw);
+    pcmd->pgg->GetRgb(2, 0, SIZEOF(long), &lw);
     switch (lw)
     {
     case 0: // new graphics window
@@ -1469,11 +1469,11 @@ DOCPIC *DOCPIC::PdocpicNew(void)
     PGL pglclr;
     RC rc(0, 0, 16, 16);
 
-    if (pvNil == (pglclr = GL::PglNew(size(CLR), 256)))
+    if (pvNil == (pglclr = GL::PglNew(SIZEOF(CLR), 256)))
         return pvNil;
     for (i = 0; i < 256; i++)
     {
-        ClearPb(&clr, size(clr));
+        ClearPb(&clr, SIZEOF(clr));
         switch (_cact)
         {
         default:
@@ -1704,11 +1704,11 @@ DOCGPT *DOCGPT::PdocgptNew(void)
     PT pt(0, 0);
     ACR acr63(63), acr127(127), acr191(191);
 
-    if (pvNil == (pglclr = GL::PglNew(size(CLR), 256)))
+    if (pvNil == (pglclr = GL::PglNew(SIZEOF(CLR), 256)))
         return pvNil;
     for (i = 0; i < 256; i++)
     {
-        ClearPb(&clr, size(clr));
+        ClearPb(&clr, SIZEOF(clr));
         switch (_cact)
         {
         default:
@@ -1792,17 +1792,17 @@ DOCGPT *DOCGPT::PdocgptNew(void)
         pgpt = pvNil;
     }
 
-    if (pvNil == (pglclr = GL::PglNew(size(CLR), 256)))
+    if (pvNil == (pglclr = GL::PglNew(SIZEOF(CLR), 256)))
         goto LFail;
     for (i = 0; i < 128; i++)
     {
-        ClearPb(&clr, size(clr));
+        ClearPb(&clr, SIZEOF(clr));
         clr.bGreen = byte(i * 2);
         pglclr->FPush(&clr);
     }
     for (; i < 256; i++)
     {
-        ClearPb(&clr, size(clr));
+        ClearPb(&clr, SIZEOF(clr));
         clr.bGreen = 255;
         clr.bRed = clr.bBlue = (byte)((i - 128) * 2);
         pglclr->FPush(&clr);

--- a/kauai/src/test.cpp
+++ b/kauai/src/test.cpp
@@ -216,7 +216,7 @@ void TestGl(void)
     short *qsw;
     PGL pglsw;
 
-    pglsw = GL::PglNew(size(short));
+    pglsw = GL::PglNew(SIZEOF(short));
     if (pvNil == pglsw)
     {
         Bug("PglNew failed");
@@ -332,7 +332,7 @@ void TestFil(void)
         AssertPo(pfil, 0);
         AssertDo(pfil->FSetFpMac(100), 0);
         AssertDo(pfil->FpMac() == 100, 0);
-        AssertDo(pfil->FWriteRgb(&fni, size(fni), 0), 0);
+        AssertDo(pfil->FWriteRgb(&fni, SIZEOF(fni), 0), 0);
         pfil->SetTemp(fTrue);
         pfil->Mark();
         ReleasePpo(&pfil);
@@ -500,7 +500,7 @@ void TestCfl(void)
             AssertDo(FEqualRgb(stn.Prgch(), perel->psz, stn.Cch()), 0);
             AssertDo(pcfl->FFind(perel->ctg, perel->cno, &blck), 0);
             AssertDo(blck.FRead(rgch), 0);
-            AssertDo(FEqualRgb(rgch, perel->psz, CchSz(perel->psz) * size(achar)), 0);
+            AssertDo(FEqualRgb(rgch, perel->psz, CchSz(perel->psz) * SIZEOF(achar)), 0);
         }
 
         // copy all the chunks - they should already be there, but this
@@ -540,8 +540,8 @@ void TestCfl(void)
             AssertDo(pcfl->FGetName(cki.ctg, cki.cno, &stn), 0);
             AssertDo(pcfl->FFind(cki.ctg, cki.cno, &blck), 0);
             AssertDo(blck.FRead(rgch), 0);
-            AssertDo(FEqualRgb(rgch, stn.Prgch(), stn.Cch() * size(achar)), 0);
-            AssertDo(stn.Cch() * size(achar) == blck.Cb(), 0);
+            AssertDo(FEqualRgb(rgch, stn.Prgch(), stn.Cch() * SIZEOF(achar)), 0);
+            AssertDo(stn.Cch() * SIZEOF(achar) == blck.Cb(), 0);
         }
 
         // copy all the chunks back

--- a/kauai/tools/kpack.cpp
+++ b/kauai/tools/kpack.cpp
@@ -140,10 +140,10 @@ int __cdecl main(int cpszs, char *prgpszs[])
     {
         long lwSwapped;
 
-        if (floSrc.cb < size(long))
+        if (floSrc.cb < SIZEOF(long))
             goto LBadSrc;
 
-        if (!floSrc.FReadRgb(&lwSig, size(long), 0))
+        if (!floSrc.FReadRgb(&lwSig, SIZEOF(long), 0))
         {
             fprintf(stderr, "Reading source file failed\n\n");
             goto LFail;
@@ -162,7 +162,7 @@ int __cdecl main(int cpszs, char *prgpszs[])
             goto LFail;
         }
 
-        blck.Set(floSrc.pfil, size(long), floSrc.cb - size(long), fPacked);
+        blck.Set(floSrc.pfil, SIZEOF(long), floSrc.cb - SIZEOF(long), fPacked);
         if (fPacked && !blck.FUnpackData())
         {
             fprintf(stderr, "Unpacking source failed\n\n");
@@ -183,13 +183,13 @@ int __cdecl main(int cpszs, char *prgpszs[])
             lwSig = klwSigPackedFile;
         else
             lwSig = klwSigUnpackedFile;
-        if (!floDst.pfil->FWriteRgb(&lwSig, size(long), 0))
+        if (!floDst.pfil->FWriteRgb(&lwSig, SIZEOF(long), 0))
         {
             fprintf(stderr, "Writing destination failed\n\n");
             goto LFail;
         }
 
-        floDst.fp = size(long);
+        floDst.fp = SIZEOF(long);
         floDst.cb = blck.Cb(fTrue);
     }
 

--- a/kauai/tools/mkmbmp.cpp
+++ b/kauai/tools/mkmbmp.cpp
@@ -155,7 +155,7 @@ int __cdecl main(int cpszs, char *prgpszs[])
         fprintf(stderr, "Couldn't create destination file\n\n");
         goto LFail;
     }
-    flo.fp = size(long);
+    flo.fp = SIZEOF(long);
     flo.cb = pmbmp->CbOnFile();
 
     if (cfmtNil != cfmt)
@@ -175,7 +175,7 @@ int __cdecl main(int cpszs, char *prgpszs[])
             lwSig = klwSigPackedFile;
             flo.cb = blck.Cb(fTrue);
         }
-        if (!flo.pfil->FWriteRgb(&lwSig, size(long), 0) || !blck.FWriteToFlo(&flo, fTrue))
+        if (!flo.pfil->FWriteRgb(&lwSig, SIZEOF(long), 0) || !blck.FWriteToFlo(&flo, fTrue))
         {
             fprintf(stderr, "writing to destination file failed\n\n");
             goto LFail;
@@ -184,7 +184,7 @@ int __cdecl main(int cpszs, char *prgpszs[])
     else
     {
         lwSig = klwSigUnpackedFile;
-        if (!flo.pfil->FWriteRgb(&lwSig, size(long), 0) || !pmbmp->FWriteFlo(&flo))
+        if (!flo.pfil->FWriteRgb(&lwSig, SIZEOF(long), 0) || !pmbmp->FWriteFlo(&flo))
         {
             fprintf(stderr, "writing to destination file failed\n\n");
             goto LFail;


### PR DESCRIPTION
Unfortunately as not all tools are built by default, the previous change to replace the `size()` macro with a new `SIZEOF()` macro missed the conversion in several files. Update the remaining files accordingly.