### PR TITLE
Remove compile warnings for writable strings 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(MSVC)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # Compiling with ClangCL
     # Disable warnings about string literals
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /clang:-Wno-multichar /clang:-Wno-writable-strings")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /clang:-Wno-multichar")
 
     # FUTURE: Fix dangling-else warnings
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /clang:-Wno-dangling-else")
@@ -22,11 +22,6 @@ if(MSVC)
     # Disable SafeSEH: required to link BRender
     # TODO: fix FindBRender to set this correctly when compiling with ClangCL
     set(CMAKE_EXE_LINKER_FLAGS "/SAFESEH:NO")
-
-  else()
-    # permissive forces C++14 const char* as default for literals
-    # this flag re-enables the auto-conversion for the microsoft compiler
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:strictStrings-")
   endif()
 endif()
 

--- a/bren/inc/camera.h
+++ b/bren/inc/camera.h
@@ -31,7 +31,7 @@ extern "C"
         /*
          * Optional identifier
          */
-        char *identifier;
+        const char *identifier;
 
         /*
          * Type of camera

--- a/bren/inc/fwproto.h
+++ b/bren/inc/fwproto.h
@@ -205,7 +205,7 @@ extern "C"
 
     void BR_PUBLIC_ENTRY BrMaterialUpdate(br_material *material, br_uint_16 flags);
 
-    br_material *BR_PUBLIC_ENTRY BrMaterialAllocate(char *name);
+    br_material *BR_PUBLIC_ENTRY BrMaterialAllocate(const char *name);
     void BR_PUBLIC_ENTRY BrMaterialFree(br_material *m);
 
     /*

--- a/bren/tmap.cpp
+++ b/bren/tmap.cpp
@@ -336,7 +336,7 @@ bool TMAP::FWriteTmapChkFile(PFNI pfniDst, bool fCompress, PMSNK pmsnkErr)
 
     bool fRet = fFalse;
     int32_t lwSig;
-    PSZ pszErr = pvNil;
+    PCSZ pszErr = pvNil;
     FLO flo;
 
     if (pvNil == (flo.pfil = FIL::PfilCreate(pfniDst)))

--- a/inc/movie.h
+++ b/inc/movie.h
@@ -453,7 +453,7 @@ class MCC : public MCC_PAR
     virtual void StartListenerEasel(void)
     {
     } // Tells the client to start up the listener easel.
-    virtual bool GetFniSave(FNI *pfni, int32_t lFilterLabel, int32_t lFilterExt, int32_t lTitle, PSZ lpstrDefExt,
+    virtual bool GetFniSave(FNI *pfni, int32_t lFilterLabel, int32_t lFilterExt, int32_t lTitle, PCSZ lpstrDefExt,
                             PSTN pstnDefFileName)
     {
         return fFalse;

--- a/inc/movie.h
+++ b/inc/movie.h
@@ -453,7 +453,7 @@ class MCC : public MCC_PAR
     virtual void StartListenerEasel(void)
     {
     } // Tells the client to start up the listener easel.
-    virtual bool GetFniSave(FNI *pfni, int32_t lFilterLabel, int32_t lFilterExt, int32_t lTitle, LPTSTR lpstrDefExt,
+    virtual bool GetFniSave(FNI *pfni, int32_t lFilterLabel, int32_t lFilterExt, int32_t lTitle, PSZ lpstrDefExt,
                             PSTN pstnDefFileName)
     {
         return fFalse;

--- a/inc/utest.h
+++ b/inc/utest.h
@@ -172,7 +172,7 @@ class APP : public APP_PAR
     bool _FFindMsKidsDir(void);
     bool _FFindMsKidsDirAt(FNI *path);
     bool _FCantFindFileDialog(PSTN pstn);
-    bool _FGenericError(PSTZ message);
+    bool _FGenericError(PSZ message);
     bool _FGenericError(PSTN message);
     bool _FGenericError(FNI *path);
     bool _FGetUserName(void);

--- a/inc/utest.h
+++ b/inc/utest.h
@@ -172,7 +172,7 @@ class APP : public APP_PAR
     bool _FFindMsKidsDir(void);
     bool _FFindMsKidsDirAt(FNI *path);
     bool _FCantFindFileDialog(PSTN pstn);
-    bool _FGenericError(PSZ message);
+    bool _FGenericError(PCSZ message);
     bool _FGenericError(PSTN message);
     bool _FGenericError(FNI *path);
     bool _FGetUserName(void);
@@ -364,7 +364,7 @@ class APP : public APP_PAR
     void EnableAccel(void);
 
     // Registry access function
-    bool FGetSetRegKey(PSZ pszValueName, void *pvData, int32_t cbData, uint32_t grfreg = fregSetDefault,
+    bool FGetSetRegKey(PCSZ pszValueName, void *pvData, int32_t cbData, uint32_t grfreg = fregSetDefault,
                        bool *pfNoValue = pvNil);
 
     // Movie handoff routines

--- a/kauai/src/appb.h
+++ b/kauai/src/appb.h
@@ -263,7 +263,7 @@ class APPB : public APPB_PAR
     virtual int32_t DypTextDef(void);
 
     // basic alert handling
-    virtual tribool TGiveAlertSz(const PSZ psz, int32_t bk, int32_t cok);
+    virtual tribool TGiveAlertSz(const PCSZ psz, int32_t bk, int32_t cok);
 
     // common commands
     virtual bool FCmdQuit(PCMD pcmd);

--- a/kauai/src/appbwin.cpp
+++ b/kauai/src/appbwin.cpp
@@ -73,7 +73,7 @@ bool APPB::_FInitOS(void)
 {
     AssertThis(0);
     STN stnApp;
-    PSZ pszAppWndCls = PszLit("APP");
+    PCSZ pszAppWndCls = PszLit("APP");
 
     // get the app name
     GetStnAppName(&stnApp);
@@ -841,7 +841,7 @@ bool APPB::FAssertProcApp(PSZS pszsFile, int32_t lwLine, PSZS pszsMsg, void *pv,
     const int32_t kclwChain = 10;
     STN stn0, stn1, stn2;
     int tmc;
-    PSZ psz;
+    PCSZ psz;
     int32_t cact;
     int32_t *plw;
     int32_t ilw;
@@ -1009,7 +1009,7 @@ bool APPB::FAssertProcApp(PSZS pszsFile, int32_t lwLine, PSZS pszsMsg, void *pv,
     Put an alert up. Return which button was hit. Returns tYes for yes
     or ok; tNo for no; tMaybe for cancel.
 ***************************************************************************/
-tribool APPB::TGiveAlertSz(const PSZ psz, int32_t bk, int32_t cok)
+tribool APPB::TGiveAlertSz(const PCSZ psz, int32_t bk, int32_t cok)
 {
     AssertThis(0);
     AssertSz(psz);

--- a/kauai/src/chcm.cpp
+++ b/kauai/src/chcm.cpp
@@ -16,7 +16,7 @@ RTCLASS(CHCM)
 RTCLASS(CHLX)
 RTCLASS(CHDC)
 
-PSZ _mpertpsz[] = {
+PCSZ _mpertpsz[] = {
     PszLit("no error"),
     PszLit("Internal allocation error"),                      // ertOom
     PszLit("Can't open the given file"),                      // ertOpenFile
@@ -133,7 +133,7 @@ void CHCM::MarkMem(void)
     Registers an error, prints error message with filename and line number.
     pszMessage may be nil.
 ***************************************************************************/
-void CHCM::_Error(int32_t ert, const PSZ pszMessage)
+void CHCM::_Error(int32_t ert, const PCSZ pszMessage)
 {
     AssertThis(0);
     AssertIn(ert, ertNil, ertLim);
@@ -209,7 +209,7 @@ void CHCM::_GetRgbFromLw(int32_t lw, uint8_t *prgb)
     Checks if data is already in the buffer (and issues an error) for a
     non-buffer command such as metafile import.
 ***************************************************************************/
-void CHCM::_ErrorOnData(PSZ pszPreceed)
+void CHCM::_ErrorOnData(PCSZ pszPreceed)
 {
     AssertThis(0);
     AssertSz(pszPreceed);

--- a/kauai/src/chcm.h
+++ b/kauai/src/chcm.h
@@ -70,7 +70,7 @@ enum
 // lookup table for keywords
 struct KEYTT
 {
-    const PSZ pszKeyword;
+    const PCSZ pszKeyword;
     int32_t tt;
 };
 
@@ -210,9 +210,9 @@ class CHCM : public CHCM_PAR
         PSTN pstn;
     };
 
-    void _Error(int32_t ert, PSZ pszMessage = pvNil);
+    void _Error(int32_t ert, PCSZ pszMessage = pvNil);
     void _GetRgbFromLw(int32_t lw, uint8_t *prgb);
-    void _ErrorOnData(PSZ pszPreceed);
+    void _ErrorOnData(PCSZ pszPreceed);
     bool _FParseParenHeader(PHP *prgphp, int32_t cphpMax, int32_t *pcphp);
     bool _FGetCleanTok(TOK *ptok, bool fEofOk = fFalse);
     void _SkipPastTok(int32_t tt);

--- a/kauai/src/chse.h
+++ b/kauai/src/chse.h
@@ -65,12 +65,12 @@ class CHSE : public CHSE_PAR
     bool FDumpScript(PSCPT pscpt, PSCCB psccb);
 
     // General sz emitting routines
-    void DumpSz(PSZ psz)
+    void DumpSz(PCSZ psz)
     {
         AssertThis(fchseDump);
         _pmsnkDump->ReportLine(psz);
     }
-    void Error(PSZ psz)
+    void Error(PCSZ psz)
     {
         AssertThis(fchseNil);
         _fError = fTrue;

--- a/kauai/src/chunk.cpp
+++ b/kauai/src/chunk.cpp
@@ -2360,7 +2360,7 @@ bool CFL::FAdd(int32_t cb, CTG ctg, CNO *pcno, PBLCK pblck)
 /***************************************************************************
     Add a new chunk and write the pv to it.
 ***************************************************************************/
-bool CFL::FAddPv(void *pv, int32_t cb, CTG ctg, CNO *pcno)
+bool CFL::FAddPv(const void *pv, int32_t cb, CTG ctg, CNO *pcno)
 {
     AssertThis(0);
     AssertVarMem(pcno);

--- a/kauai/src/chunk.h
+++ b/kauai/src/chunk.h
@@ -207,7 +207,7 @@ class CFL : public CFL_PAR
 
     // creating and replacing chunks
     bool FAdd(int32_t cb, CTG ctg, CNO *pcno, PBLCK pblck = pvNil);
-    bool FAddPv(void *pv, int32_t cb, CTG ctg, CNO *pcno);
+    bool FAddPv(const void *pv, int32_t cb, CTG ctg, CNO *pcno);
     bool FAddHq(HQ hq, CTG ctg, CNO *pcno);
     bool FAddBlck(PBLCK pblckSrc, CTG ctg, CNO *pcno);
     bool FPut(int32_t cb, CTG ctg, CNO cno, PBLCK pblck = pvNil);

--- a/kauai/src/file.cpp
+++ b/kauai/src/file.cpp
@@ -1397,7 +1397,7 @@ PFIL MSFIL::PfilRelease(void)
 /***************************************************************************
     Dump a line to the file.
 ***************************************************************************/
-void MSFIL::ReportLine(PSZ psz)
+void MSFIL::ReportLine(const PCSZ psz)
 {
     AssertThis(0);
     AssertNilOrPo(_pfil, 0);
@@ -1413,7 +1413,7 @@ void MSFIL::ReportLine(PSZ psz)
 /***************************************************************************
     Dump some text to the file.
 ***************************************************************************/
-void MSFIL::Report(PSZ psz)
+void MSFIL::Report(PCSZ psz)
 {
     AssertThis(0);
     AssertNilOrPo(_pfil, 0);

--- a/kauai/src/file.h
+++ b/kauai/src/file.h
@@ -304,8 +304,8 @@ class MSNK : public MSNK_PAR
     RTCLASS_INLINE(MSNK)
 
   public:
-    virtual void ReportLine(const PSZ psz) = 0;
-    virtual void Report(const PSZ psz) = 0;
+    virtual void ReportLine(const PCSZ psz) = 0;
+    virtual void Report(const PCSZ psz) = 0;
     virtual bool FError(void) = 0;
 };
 
@@ -330,8 +330,8 @@ class MSFIL : public MSFIL_PAR
     MSFIL(PFIL pfil = pvNil);
     ~MSFIL(void);
 
-    virtual void ReportLine(const PSZ psz);
-    virtual void Report(const PSZ psz);
+    virtual void ReportLine(const PCSZ psz);
+    virtual void Report(const PCSZ psz);
     virtual bool FError(void);
 
     void SetFile(PFIL pfil);

--- a/kauai/src/fni.h
+++ b/kauai/src/fni.h
@@ -91,8 +91,8 @@ class FNI : public FNI_PAR
     bool FGetSave(FTG ftg, PST pstPrompt, PST pstDefault);
     bool FBuild(int32_t lwVol, int32_t lwDir, PSTN pstn, FTG ftg);
 #elif defined(WIN)
-    bool FGetOpen(achar *prgchFilter, HWND hwndOwner);
-    bool FGetSave(achar *prgchFilter, HWND hwndOwner);
+    bool FGetOpen(const achar *prgchFilter, HWND hwndOwner);
+    bool FGetSave(const achar *prgchFilter, HWND hwndOwner);
     bool FSearchInPath(PSTN pstn, PSTN pstnEnv = pvNil);
 #endif                                                   // WIN
     bool FBuildFromPath(PSTN pstn, FTG ftgDef = ftgNil); // REVIEW shonk: Mac: implement

--- a/kauai/src/fniwin.cpp
+++ b/kauai/src/fniwin.cpp
@@ -52,7 +52,7 @@ FNI::FNI(void)
 /***************************************************************************
     Get an fni (for opening) from the user.
 ***************************************************************************/
-bool FNI::FGetOpen(achar *prgchFilter, HWND hwndOwner)
+bool FNI::FGetOpen(const achar *prgchFilter, HWND hwndOwner)
 {
     AssertThis(0);
     AssertNilOrVarMem(prgchFilter);
@@ -89,7 +89,7 @@ bool FNI::FGetOpen(achar *prgchFilter, HWND hwndOwner)
 /***************************************************************************
     Get an fni (for saving) from the user.
 ***************************************************************************/
-bool FNI::FGetSave(achar *prgchFilter, HWND hwndOwner)
+bool FNI::FGetSave(const achar *prgchFilter, HWND hwndOwner)
 {
     AssertThis(0);
     AssertNilOrVarMem(prgchFilter);

--- a/kauai/src/ft.cpp
+++ b/kauai/src/ft.cpp
@@ -89,8 +89,8 @@ RND vrnd;
 
 ACR _rgacr[] = {kacrBlack,   kacrBlue,   kacrGreen, kacrCyan,  kacrRed,
                 kacrMagenta, kacrYellow, kacrWhite, kacrClear, kacrInvert};
-achar *_rgszColors[] = {PszLit("bla"), PszLit("blu"), PszLit("gre"), PszLit("cya"), PszLit("red"),
-                        PszLit("mag"), PszLit("yel"), PszLit("whi"), PszLit("cle"), PszLit("inv")};
+PCSZ _rgszColors[] = {PszLit("bla"), PszLit("blu"), PszLit("gre"), PszLit("cya"), PszLit("red"),
+                      PszLit("mag"), PszLit("yel"), PszLit("whi"), PszLit("cle"), PszLit("inv")};
 const int32_t _cacr = SIZEOF(_rgacr) / SIZEOF(_rgacr[0]);
 
 RTCLASS(APP)

--- a/kauai/src/groups.cpp
+++ b/kauai/src/groups.cpp
@@ -2008,7 +2008,7 @@ bool GG::FCopyEntries(PGG pggSrc, int32_t ivSrc, int32_t ivDst, int32_t cv)
 /***************************************************************************
     Append an element to the group.
 ***************************************************************************/
-bool GG::FAdd(int32_t cb, int32_t *piv, void *pv, void *pvFixed)
+bool GG::FAdd(int32_t cb, int32_t *piv, const void *pv, void *pvFixed)
 {
     AssertThis(0);
     AssertNilOrVarMem(piv);
@@ -2163,7 +2163,7 @@ PAG AG::PagDup(void)
 /***************************************************************************
     Add an element to the allocated group.
 ***************************************************************************/
-bool AG::FAdd(int32_t cb, int32_t *piv, void *pv, void *pvFixed)
+bool AG::FAdd(int32_t cb, int32_t *piv, const void *pv, void *pvFixed)
 {
     AssertThis(fobjAssertFull);
     AssertIn(cb, 0, kcbMax);

--- a/kauai/src/groups.h
+++ b/kauai/src/groups.h
@@ -280,7 +280,7 @@ class GGB : public GGB_PAR
     bool FEnsureSpace(int32_t cvAdd, int32_t cbAdd, uint32_t grfgrp = fgrpNil);
     void SetMinGrow(int32_t cvAdd, int32_t cbAdd);
 
-    virtual bool FAdd(int32_t cb, int32_t *piv = pvNil, void *pv = pvNil, void *pvFixed = pvNil) = 0;
+    virtual bool FAdd(int32_t cb, int32_t *piv = pvNil, const void *pv = pvNil, void *pvFixed = pvNil) = 0;
 
     // access to the fixed portion
     int32_t CbFixed(void)
@@ -332,7 +332,7 @@ class GG : public GG_PAR
     PGG PggDup(void);
 
     // methods required by parent class
-    virtual bool FAdd(int32_t cb, int32_t *piv = pvNil, void *pv = pvNil, void *pvFixed = pvNil);
+    virtual bool FAdd(int32_t cb, int32_t *piv = pvNil, const void *pv = pvNil, void *pvFixed = pvNil);
     virtual void Delete(int32_t iv);
 
     // new methods
@@ -367,7 +367,7 @@ class AG : public AG_PAR
     PAG PagDup(void);
 
     // methods required by parent class
-    virtual bool FAdd(int32_t cb, int32_t *piv = pvNil, void *pv = pvNil, void *pvFixed = pvNil);
+    virtual bool FAdd(int32_t cb, int32_t *piv = pvNil, const void *pv = pvNil, void *pvFixed = pvNil);
     virtual void Delete(int32_t iv);
 };
 

--- a/kauai/src/mssio.cpp
+++ b/kauai/src/mssio.cpp
@@ -26,7 +26,7 @@ MSSIO::MSSIO(FILE *pfile)
 /***************************************************************************
     Prints a message to stderr.
 ***************************************************************************/
-void MSSIO::ReportLine(const PSZ psz)
+void MSSIO::ReportLine(const PCSZ psz)
 {
     AssertThis(0);
     AssertSz(psz);
@@ -41,7 +41,7 @@ void MSSIO::ReportLine(const PSZ psz)
 /***************************************************************************
     Dump a line to stdout.
 ***************************************************************************/
-void MSSIO::Report(const PSZ psz)
+void MSSIO::Report(const PCSZ psz)
 {
     AssertThis(0);
     AssertSz(psz);

--- a/kauai/src/mssio.h
+++ b/kauai/src/mssio.h
@@ -29,8 +29,8 @@ class MSSIO : public MSSIO_PAR
 
   public:
     MSSIO(FILE *pfile);
-    virtual void ReportLine(PSTZ pstz);
-    virtual void Report(PSTZ pstz);
+    virtual void ReportLine(const PSZ psz);
+    virtual void Report(const PSZ psz);
     virtual bool FError(void);
 };
 

--- a/kauai/src/mssio.h
+++ b/kauai/src/mssio.h
@@ -29,8 +29,8 @@ class MSSIO : public MSSIO_PAR
 
   public:
     MSSIO(FILE *pfile);
-    virtual void ReportLine(const PSZ psz);
-    virtual void Report(const PSZ psz);
+    virtual void ReportLine(const PCSZ psz);
+    virtual void Report(const PCSZ psz);
     virtual bool FError(void);
 };
 

--- a/kauai/src/scrcom.cpp
+++ b/kauai/src/scrcom.cpp
@@ -99,8 +99,8 @@ ASSERTNAME
 RTCLASS(SCCB)
 
 // common error messages
-PSZ _pszOom = PszLit("Out of memory");
-PSZ _pszSyntax = PszLit("Syntax error");
+PCSZ _pszOom = PszLit("Out of memory");
+PCSZ _pszSyntax = PszLit("Syntax error");
 
 // name to op lookup table for post-fix compilation
 SZOP _rgszop[] = {
@@ -196,7 +196,7 @@ AROP _rgarop[] = {
     {opNil, pvNil, 0, 0, 0, fTrue},
 };
 
-PSZ _rgpszKey[] = {
+PCSZ _rgpszKey[] = {
     PszLit("If"), PszLit("Elif"), PszLit("Else"), PszLit("End"), PszLit("While"), PszLit("Break"), PszLit("Continue"),
 };
 
@@ -556,7 +556,7 @@ int16_t SCCB::_SwMin(void)
 /***************************************************************************
     An error occured.  Report it to the message sink.
 ***************************************************************************/
-void SCCB::_ReportError(PSZ psz)
+void SCCB::_ReportError(PCSZ psz)
 {
     AssertThis(0);
     AssertPo(_plexb, 0);
@@ -2568,7 +2568,7 @@ bool SCCB::FDisassemble(PSCPT pscpt, PMSNK pmsnk, PMSNK pmsnkError)
     STN stn;
     DVER dver;
     PGL pgllw = pscpt->_pgllw;
-    PSZ pszError = pvNil;
+    PCSZ pszError = pvNil;
     AssertPo(pgllw, 0);
     Assert(pgllw->CbEntry() == SIZEOF(int32_t), "bad script");
 

--- a/kauai/src/scrcom.h
+++ b/kauai/src/scrcom.h
@@ -125,14 +125,14 @@ enum
 struct SZOP
 {
     int32_t op;
-    PSZ psz;
+    PCSZ psz;
 };
 
 // structure to map a string to an opcode and argument information (in-fix)
 struct AROP
 {
     int32_t op;
-    PSZ psz;
+    PCSZ psz;
     int32_t clwFixed;   // number of fixed arguments
     int32_t clwVar;     // number of arguments per variable group
     int32_t cactMinVar; // minimum number of variable groups
@@ -215,7 +215,7 @@ class SCCB : public SCCB_PAR
     void _AddLabelLw(int32_t lw);
     void _PushLabelRequestLw(int32_t lw);
 
-    virtual void _ReportError(PSZ psz);
+    virtual void _ReportError(PCSZ psz);
     virtual int16_t _SwCur(void);
     virtual int16_t _SwBack(void);
     virtual int16_t _SwMin(void);

--- a/kauai/src/screxe.cpp
+++ b/kauai/src/screxe.cpp
@@ -779,7 +779,7 @@ void SCEB::_Error(bool fAssert)
 /***************************************************************************
     Emits a warning with the given format string and optional parameters.
 ***************************************************************************/
-void SCEB::_WarnSz(PSZ psz, ...)
+void SCEB::_WarnSz(PCSZ psz, ...)
 {
     AssertThis(0);
     AssertSz(psz);

--- a/kauai/src/screxe.h
+++ b/kauai/src/screxe.h
@@ -168,7 +168,7 @@ class SCEB : public SCEB_PAR
     virtual int16_t _SwMin(void);
 
 #ifdef DEBUG
-    void _WarnSz(PSZ psz, ...);
+    void _WarnSz(PCSZ psz, ...);
 #endif // DEBUG
 
   public:

--- a/kauai/src/test.cpp
+++ b/kauai/src/test.cpp
@@ -352,7 +352,7 @@ void TestGg(void)
     uint32_t grf;
     int32_t cb, iv;
     uint8_t *qb;
-    PSZ psz = PszLit("0123456789ABCDEFG");
+    PCSZ psz = PszLit("0123456789ABCDEFG");
     achar rgch[100];
 
     AssertDo((pgg = GG::PggNew(0)) != pvNil, 0);
@@ -435,7 +435,7 @@ void TestCfl(void)
     {
         CTG ctg;
         CNO cno;
-        PSZ psz;
+        PCSZ psz;
         short relPar1, relPar2;
     };
 

--- a/kauai/src/utilstr.cpp
+++ b/kauai/src/utilstr.cpp
@@ -561,7 +561,7 @@ bool STN::FFormat(PSTN pstnFormat, ...)
 /***************************************************************************
     See comments for STN::FFormat
 ***************************************************************************/
-bool STN::FFormatSz(const PSZ pszFormat, ...)
+bool STN::FFormatSz(const PCSZ pszFormat, ...)
 {
     AssertThis(0);
     AssertSz(pszFormat);
@@ -999,11 +999,11 @@ bool FValidStz(PSTZ pstz)
 /***************************************************************************
     Find the length of a zero terminated string.
 ***************************************************************************/
-int32_t CchSz(const PSZ psz)
+int32_t CchSz(const PCSZ psz)
 {
     // WARNING: don't call AssertSz, since AssertSz calls CchSz!
     AssertVarMem(psz);
-    achar *pch;
+    const achar *pch;
 
     for (pch = psz; *pch != 0; pch++)
         ;
@@ -1511,7 +1511,7 @@ void AssertStz(PSTZ pstz)
 /***************************************************************************
     Make sure the sz isn't too long.
 ***************************************************************************/
-void AssertSz(PSZ psz)
+void AssertSz(PCSZ psz)
 {
     // CchSz does all the asserting we need
     int32_t cch = CchSz(psz);

--- a/kauai/src/utilstr.h
+++ b/kauai/src/utilstr.h
@@ -122,7 +122,7 @@ typedef schar SZS[kcchTotSz];
 void AssertRgch(achar *prgch, int32_t cch);
 void AssertStz(PSTZ pstz);
 void AssertSt(PST pst);
-void AssertSz(PSZ psz);
+void AssertSz(PCSZ psz);
 void AssertNilOrSz(PSZ psz);
 #else
 #define AssertRgch(prgch, cch)
@@ -143,7 +143,7 @@ bool FValidSt(PST pst);
     bytes) and CchTot means the total number of characters including
     overhead.
 ***************************************************************************/
-int32_t CchSz(const PSZ psz);
+int32_t CchSz(const PCSZ psz);
 inline int32_t CchTotSz(const PSZ psz)
 {
     return CchSz(psz) + kcchExtraSz;
@@ -374,7 +374,7 @@ class STN
         _rgch[0] = _rgch[1] = 0;
     }
     void SetRgch(const achar *prgchSrc, int32_t cch);
-    void SetSz(const PSZ pszSrc)
+    void SetSz(const PCSZ pszSrc)
     {
         SetRgch(pszSrc, CchSz(pszSrc));
     }
@@ -390,7 +390,7 @@ class STN
 
     // assignment operators
     STN &operator=(STN &stnSrc);
-    STN &operator=(PSZ pszSrc)
+    STN &operator=(PCSZ pszSrc)
     {
         SetSz(pszSrc);
         return *this;
@@ -446,7 +446,7 @@ class STN
 
     // for testing equality
     bool FEqualRgch(const achar *prgch, int32_t cch);
-    bool FEqualSz(const PSZ psz)
+    bool FEqualSz(const PCSZ psz)
     {
         return FEqualRgch(psz, CchSz(psz));
     }
@@ -482,7 +482,7 @@ class STN
     bool FRead(PBLCK pblck, int32_t ib, int32_t *pcbRead = pvNil);
 
     bool FFormat(PSTN pstnFormat, ...);
-    bool FFormatSz(const PSZ pszFormat, ...);
+    bool FFormatSz(const PCSZ pszFormat, ...);
     bool FFormatRgch(const achar *prgchFormat, int32_t cchFormat, uintptr_t *prgluData);
     bool FGetLw(int32_t *plw, int32_t lwBase = 0);
     bool FExpandControls(void);

--- a/kauai/src/utilstr.h
+++ b/kauai/src/utilstr.h
@@ -16,6 +16,7 @@
     not to, all code should use stn's.
 
     sz - zero terminated (standard C) string.
+    csz - constant zero terminated (standard C) string.
     st - length byte prefixed (standard Pascal) string.
     stz - zero terminated and length prefixed string.
     stn - string class.
@@ -105,6 +106,7 @@ enum
     String types
 ***************************************************************************/
 typedef achar *PSZ;
+typedef const achar *PCSZ;
 typedef achar *PST;
 typedef achar *PSTZ;
 typedef achar SZ[kcchTotSz];

--- a/kauai/test/kauai_test.cpp
+++ b/kauai/test/kauai_test.cpp
@@ -313,7 +313,7 @@ TEST(KauaiTests, TestGg)
     uint32_t grf;
     int32_t cb, iv;
     uint8_t *qb;
-    PSZ psz = PszLit("0123456789ABCDEFG");
+    PCSZ psz = PszLit("0123456789ABCDEFG");
     achar rgch[100];
 
     EXPECT_TRUE((pgg = GG::PggNew(0)) != pvNil);
@@ -393,7 +393,7 @@ TEST(KauaiTests, TestCfl)
     {
         CTG ctg;
         CNO cno;
-        PSZ psz;
+        PCSZ psz;
         int16_t relPar1, relPar2;
     };
 

--- a/kauai/tools/chelp.cpp
+++ b/kauai/tools/chelp.cpp
@@ -83,7 +83,7 @@ bool APP::_FInit(uint32_t grfapp, uint32_t grfgob, int32_t ginDef)
 
     struct LANG
     {
-        PSZ psz;
+        PCSZ psz;
         int32_t sclid;
     };
     static LANG _rglang[] = {

--- a/src/studio/mminstal.cpp
+++ b/src/studio/mminstal.cpp
@@ -312,7 +312,7 @@ WORD wHaveICMCodec(DWORD dwReqCodec)
 
 ******************************************************************************/
 
-WORD wHaveMCI(PSZ dwDeviceType)
+WORD wHaveMCI(PCSZ dwDeviceType)
 {
     MCI_OPEN_PARMS mciOpen;
     MCIERROR mciErr;

--- a/src/studio/mminstal.cpp
+++ b/src/studio/mminstal.cpp
@@ -312,7 +312,7 @@ WORD wHaveICMCodec(DWORD dwReqCodec)
 
 ******************************************************************************/
 
-WORD wHaveMCI(LPSTR dwDeviceType)
+WORD wHaveMCI(PSZ dwDeviceType)
 {
     MCI_OPEN_PARMS mciOpen;
     MCIERROR mciErr;
@@ -483,7 +483,7 @@ int WINAPI
 {
   if(HWD_SUCCESS == wHaveWaveDevice(WAVE_FORMAT_2M08)) // 22kHz, Mono, 8bit
   {
-    if(wHaveMCI("WAVEAUDIO"))
+    if(wHaveMCI(PszLit("WAVEAUDIO")))
         // MCI for audio is not installed
       wInstallComp(IC_MCI_SOUND);
 
@@ -498,7 +498,7 @@ int WINAPI
   } // have wave device
 
 
-  if(wHaveMCI("AVIVIDEO"))
+  if(wHaveMCI(PszLit("AVIVIDEO")))
       // MCI for video is not installed
     wInstallComp(IC_MCI_VFW);
 

--- a/src/studio/mminstal.h
+++ b/src/studio/mminstal.h
@@ -49,7 +49,7 @@ extern "C"
     WORD wHaveACM();
     WORD wHaveACMCodec(DWORD dwReqCodec);
     WORD wHaveICMCodec(DWORD dwReqCodec);
-    WORD wHaveMCI(LPSTR dwDeviceType);
+    WORD wHaveMCI(PSZ dwDeviceType);
 
 #ifdef __cplusplus
 }

--- a/src/studio/mminstal.h
+++ b/src/studio/mminstal.h
@@ -49,7 +49,7 @@ extern "C"
     WORD wHaveACM();
     WORD wHaveACMCodec(DWORD dwReqCodec);
     WORD wHaveICMCodec(DWORD dwReqCodec);
-    WORD wHaveMCI(PSZ dwDeviceType);
+    WORD wHaveMCI(PCSZ dwDeviceType);
 
 #ifdef __cplusplus
 }

--- a/src/studio/utest.cpp
+++ b/src/studio/utest.cpp
@@ -1141,7 +1141,7 @@ bool APP::_FGenericError(FNI *path)
 /***************************************************************************
     Report that 3DMM ran into a generic error
 ***************************************************************************/
-bool APP::_FGenericError(PSTZ message)
+bool APP::_FGenericError(PSZ message)
 {
     STN stn;
     stn.SetSz(message);

--- a/src/studio/utest.cpp
+++ b/src/studio/utest.cpp
@@ -49,8 +49,8 @@ const uint32_t kdtsMaxResSwitchDlg = 15 * kdtsSecond;
 // 2MB cache per source for TAGM
 const uint32_t kcbCacheTagm = 2048 * 1024;
 
-static PSZ kpszAppWndCls = PszLit("3DMOVIE");
-const PSZ kpszOpenFile = PszLit("3DMMOpen.tmp");
+static PCSZ kpszAppWndCls = PszLit("3DMOVIE");
+const PCSZ kpszOpenFile = PszLit("3DMMOpen.tmp");
 
 const int32_t klwOpenDoc = 0x12123434; // arbitrary wParam for WM_USER
 
@@ -1141,7 +1141,7 @@ bool APP::_FGenericError(FNI *path)
 /***************************************************************************
     Report that 3DMM ran into a generic error
 ***************************************************************************/
-bool APP::_FGenericError(PSZ message)
+bool APP::_FGenericError(PCSZ message)
 {
     STN stn;
     stn.SetSz(message);
@@ -1407,7 +1407,7 @@ bool APP::_FWriteUserData(void)
     Returns:  fTrue if all actions necessary could be performed
 
 ************************************************************ PETED ***********/
-bool APP::FGetSetRegKey(PSZ pszValueName, void *pvData, int32_t cbData, uint32_t grfreg, bool *pfNoValue)
+bool APP::FGetSetRegKey(PCSZ pszValueName, void *pvData, int32_t cbData, uint32_t grfreg, bool *pfNoValue)
 {
     AssertBaseThis(0);
     AssertSz(pszValueName);
@@ -3494,7 +3494,7 @@ typedef LONG(WINAPI *PFNCHDS)(LPDEVMODEW lpDevMode, DWORD dwFlags);
 const PSZ kpszChds = PszLit("ChangeDisplaySettingsW");
 #else
 typedef LONG(WINAPI *PFNCHDS)(LPDEVMODEA lpDevMode, DWORD dwFlags);
-const PSZ kpszChds = PszLit("ChangeDisplaySettingsA");
+const PCSZ kpszChds = PszLit("ChangeDisplaySettingsA");
 #endif // !UNICODE
 
 #ifdef BUG1920


### PR DESCRIPTION
This PR updates the 3DMMEx code to remove warnings caused by writable strings: modern ISO C++ compilers will generate an error if an attempt is made to cast a `const char *` to `char *` and so `CMakeLists.txt` disables these errors to allow the compile to succeed.

To resolve this issue we first fix up various function definitions which then allows us to proceed with the next step, which is to introduce a new `PCSZ` (Pointer to Constant String Zero-terminated) typedef which is the constant equivalent of `PSZ`. All the generated warnings/errors are then fixed by switching the required instances of `PSZ` over to `PCSZ` and then finally the warnings/errors are re-enabled during the compile to prevent such errors from occurring in future.