### PR TITLE
Add x64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,3 +106,37 @@ jobs:
         shell: cmd
         run: |
           cd build/x64-msvc-debug && ctest --output-on-failure --timeout 60
+
+  compile-clang-x64:
+    name: Windows Clang Win64 x64
+    runs-on: windows-latest
+    env:
+        VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Use Visual Studio clang
+        # Move the separate Github Action LLVM install out of the way to prevent it from being
+        # detected by cmake: this causes us to fall back to the version provided by VS instead
+        run: |
+          Rename-Item -path "C:\Program Files\LLVM" -NewName "LLVM.ignore"
+      - name: CMake Generate
+        shell: cmd
+        run: |
+          call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
+          cmake --preset x64-clangcl-debug -D3DMM_PACKAGE_WIX=OFF
+      - name: CMake Build
+        shell: cmd
+        run: |
+          call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
+          cmake --build build/x64-clangcl-debug --target tools studio KauaiTest
+      - name: Run tests
+        shell: cmd
+        run: |
+          cd build/x64-clangcl-debug && ctest --output-on-failure --timeout 60

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,32 @@ jobs:
         shell: cmd
         run: |
           cd build/x86-clangcl-debug && ctest --output-on-failure --timeout 60
+
+  compile-msvc-x64:
+    name: Windows MSVC Win64 x64
+    runs-on: windows-latest
+    env:
+        VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: CMake Generate
+        shell: cmd
+        run: |
+          call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
+          cmake --preset x64-msvc-debug -D3DMM_PACKAGE_WIX=OFF
+      - name: CMake Build
+        shell: cmd
+        run: |
+          call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat" x64
+          cmake --build build/x64-msvc-debug --target tools studio KauaiTest
+      - name: Run tests
+        shell: cmd
+        run: |
+          cd build/x64-msvc-debug && ctest --output-on-failure --timeout 60

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,6 @@ if (CMAKE_C_BYTE_ORDER MATCHES LITTLE_ENDIAN)
 endif()
 
 
-if (NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
-  message(FATAL_ERROR "Cannot compile for 64-bit yet")
-endif()
-
 # Configure version header
 execute_process(
   COMMAND git describe --tags --always

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,108 +1,149 @@
 {
   "version": 3,
-  "configurePresets": [
-    {
-      "name": "base",
-      "hidden": true,
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "installDir": "${sourceDir}/dist/${presetName}",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-      }
-    },
-    {
-      "name": "msvc-base",
-      "inherits": "base",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "name": "msvc-x86-base",
-      "inherits": "msvc-base",
-      "hidden": true,
-      "architecture": {
-        "value": "x86",
-        "strategy": "external"
-      }
-    },
-    {
-      "displayName": "MSVC x86 Release",
-      "name": "x86-msvc-release",
-      "inherits": "msvc-x86-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "displayName": "MSVC x86 Debug",
-      "name": "x86-msvc-debug",
-      "inherits": "msvc-x86-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "displayName": "MSVC x86 RelWithDebInfo",
-      "name": "x86-msvc-relwithdebinfo",
-      "inherits": "msvc-x86-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
-      "displayName": "MSVC x86 MinSizeRel",
-      "name": "x86-msvc-minsizerel",
-      "inherits": "msvc-x86-base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "MinSizeRel"
-      }
-    },
-    {
-      "name": "clangcl:base",
-      "inherits": "base",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang-cl",
-        "CMAKE_C_COMPILER": "clang-cl"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "name": "clangcl:x86:base",
-      "inherits": "clangcl:base",
-      "hidden": true,
-      "architecture": {
-        "value": "x86",
-        "strategy": "external"
-      }
-    },
-    {
-      "displayName": "ClangCL x86 Debug",
-      "name": "x86-clangcl-debug",
-      "inherits": "clangcl:x86:base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "displayName": "ClangCL x86 RelWithDebInfo",
-      "name": "x86-clangcl-relwithdebinfo",
-      "inherits": "clangcl:x86:base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    }
-  ]
+    "configurePresets": [
+        {
+            "name": "base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "installDir": "${sourceDir}/dist/${presetName}",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            }
+        },
+        {
+            "name": "msvc-base",
+            "inherits": "base",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "cl"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "msvc-x86-base",
+            "inherits": "msvc-base",
+            "hidden": true,
+            "architecture": {
+                "value": "x86",
+                "strategy": "external"
+            }
+        },
+        {
+            "displayName": "MSVC x86 Release",
+            "name": "x86-msvc-release",
+            "inherits": "msvc-x86-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "displayName": "MSVC x86 Debug",
+            "name": "x86-msvc-debug",
+            "inherits": "msvc-x86-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "displayName": "MSVC x86 RelWithDebInfo",
+            "name": "x86-msvc-relwithdebinfo",
+            "inherits": "msvc-x86-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "displayName": "MSVC x86 MinSizeRel",
+            "name": "x86-msvc-minsizerel",
+            "inherits": "msvc-x86-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "MinSizeRel"
+            }
+        },
+        {
+            "name": "clangcl:base",
+            "inherits": "base",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang-cl",
+                "CMAKE_C_COMPILER": "clang-cl"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "clangcl:x86:base",
+            "inherits": "clangcl:base",
+            "hidden": true,
+            "architecture": {
+                "value": "x86",
+                "strategy": "external"
+            }
+        },
+        {
+            "displayName": "ClangCL x86 Debug",
+            "name": "x86-clangcl-debug",
+            "inherits": "clangcl:x86:base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "displayName": "ClangCL x86 RelWithDebInfo",
+            "name": "x86-clangcl-relwithdebinfo",
+            "inherits": "clangcl:x86:base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "name": "msvc-x64-base",
+            "inherits": "msvc-base",
+            "hidden": true,
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            }
+        },
+        {
+            "displayName": "MSVC x64 Release",
+            "name": "x64-msvc-release",
+            "inherits": "msvc-x64-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "displayName": "MSVC x64 Debug",
+            "name": "x64-msvc-debug",
+            "inherits": "msvc-x64-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "displayName": "MSVC x64 RelWithDebInfo",
+            "name": "x64-msvc-relwithdebinfo",
+            "inherits": "msvc-x64-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "displayName": "MSVC x64 MinSizeRel",
+            "name": "x64-msvc-minsizerel",
+            "inherits": "msvc-x64-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "MinSizeRel"
+            }
+        }
+    ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -144,6 +144,31 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "MinSizeRel"
             }
+        },
+        {
+            "name": "clangcl:x64:base",
+            "inherits": "clangcl:base",
+            "hidden": true,
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            }
+        },
+        {
+            "displayName": "ClangCL x64 Debug",
+            "name": "x64-clangcl-debug",
+            "inherits": "clangcl:x64:base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "displayName": "ClangCL x64 RelWithDebInfo",
+            "name": "x64-clangcl-relwithdebinfo",
+            "inherits": "clangcl:x64:base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
         }
     ]
 }

--- a/inc/srec.h
+++ b/inc/srec.h
@@ -111,7 +111,7 @@ class SREC : public SREC_PAR
 
     bool _FOpenRecord();
     bool _FCloseRecord();
-    static void _WaveInProc(HWAVEIN hwi, UINT uMsg, DWORD dwInstance, DWORD dwParam1, DWORD dwParam2);
+    static void _WaveInProc(HWAVEIN hwi, UINT uMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2);
 
   protected:
     bool _FInit(int32_t csampSec, int32_t cchan, int32_t cbSample, uint32_t dtsMax);

--- a/kauai/src/appb.cpp
+++ b/kauai/src/appb.cpp
@@ -527,7 +527,7 @@ bool APPB::FEnableAppCmd(PCMD pcmd, uint32_t *pgrfeds)
         break;
 
     case cidChooseWnd:
-        if ((HWND)pcmd->rglw[0] == GOB::HwndMdiActive())
+        if ((HWND)(*(uintptr_t *)pcmd->rglw) == GOB::HwndMdiActive())
             *pgrfeds |= fedsCheck;
         else
             *pgrfeds |= fedsUncheck;
@@ -551,7 +551,7 @@ bool APPB::FCmdChooseWnd(PCMD pcmd)
     AssertThis(0);
     AssertVarMem(pcmd);
 
-    GOB::MakeHwndActive((HWND)pcmd->rglw[0]);
+    GOB::MakeHwndActive((HWND)(*(uintptr_t *)pcmd->rglw));
     return fTrue;
 }
 

--- a/kauai/src/dlgwin.cpp
+++ b/kauai/src/dlgwin.cpp
@@ -111,7 +111,7 @@ bool DLG::_FInit(void)
     for (csit = dtm.cdit, idit = 0; csit > 0; csit--)
     {
         // align to dword
-        if ((int32_t)psw & 2)
+        if ((uintptr_t)psw & 2)
             psw++;
 
         // get and skip the ditm

--- a/kauai/src/gobwin.cpp
+++ b/kauai/src/gobwin.cpp
@@ -131,7 +131,7 @@ HWND GOB::_HwndNewMdi(PSTN pstnTitle)
     hwnd = CreateMDIWindow(PszLit("MDI"), pstnTitle->Psz(), lwStyle, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
                            CW_USEDEFAULT, vwig.hwndClient, vwig.hinst, 0L);
     if (hNil != hwnd && pvNil != vpmubCur)
-        vpmubCur->FAddListCid(cidChooseWnd, (int32_t)hwnd, pstnTitle);
+        vpmubCur->FAddListCid(cidChooseWnd, (uintptr_t)hwnd, pstnTitle);
     return hwnd;
 }
 
@@ -148,7 +148,7 @@ void GOB::_DestroyHwnd(HWND hwnd)
     if (GetParent(hwnd) == vwig.hwndClient && vwig.hwndClient != hNil)
     {
         if (pvNil != vpmubCur)
-            vpmubCur->FRemoveListCid(cidChooseWnd, (int32_t)hwnd);
+            vpmubCur->FRemoveListCid(cidChooseWnd, (uintptr_t)hwnd);
         SendMessage(vwig.hwndClient, WM_MDIDESTROY, (WPARAM)hwnd, 0);
     }
     else
@@ -218,7 +218,7 @@ void GOB::SetHwndName(PSTN pstn)
     }
     if (pvNil != vpmubCur)
     {
-        vpmubCur->FChangeListCid(cidChooseWnd, (int32_t)_hwnd, pvNil, (int32_t)_hwnd, pstn);
+        vpmubCur->FChangeListCid(cidChooseWnd, (uintptr_t)_hwnd, pvNil, (uintptr_t)_hwnd, pstn);
     }
     SetWindowText(_hwnd, pstn->Psz());
 }

--- a/kauai/src/menu.h
+++ b/kauai/src/menu.h
@@ -116,9 +116,9 @@ class MUB : public MUB_PAR
     virtual void EnqueueWcid(int32_t wcid);
 #endif // WIN
 
-    virtual bool FAddListCid(int32_t cid, int32_t lw0, PSTN pstn);
-    virtual bool FRemoveListCid(int32_t cid, int32_t lw0, PSTN pstn = pvNil);
-    virtual bool FChangeListCid(int32_t cid, int32_t lwOld, PSTN pstnOld, int32_t lwNew, PSTN pstnNew);
+    virtual bool FAddListCid(int32_t cid, uintptr_t lw0, PSTN pstn);
+    virtual bool FRemoveListCid(int32_t cid, uintptr_t lw0, PSTN pstn = pvNil);
+    virtual bool FChangeListCid(int32_t cid, uintptr_t lwOld, PSTN pstnOld, uintptr_t lwNew, PSTN pstnNew);
     virtual bool FRemoveAllListCid(int32_t cid);
 };
 

--- a/kauai/src/menuwin.cpp
+++ b/kauai/src/menuwin.cpp
@@ -145,7 +145,7 @@ void MUB::EnqueueWcid(int32_t wcid)
     Adds an item identified by the given list cid, long parameter
     and string.
 ***************************************************************************/
-bool MUB::FAddListCid(int32_t cid, int32_t lw0, PSTN pstn)
+bool MUB::FAddListCid(int32_t cid, uintptr_t lw0, PSTN pstn)
 {
     AssertThis(0);
     AssertPo(pstn, 0);
@@ -179,7 +179,7 @@ bool MUB::FAddListCid(int32_t cid, int32_t lw0, PSTN pstn)
 
         if (pvNil == mlst.pgllw)
         {
-            if (pvNil == (mlst.pgllw = GL::PglNew(SIZEOF(int32_t))))
+            if (pvNil == (mlst.pgllw = GL::PglNew(SIZEOF(uintptr_t))))
             {
                 fRet = fFalse;
                 goto LAdjustSeparator;
@@ -242,7 +242,7 @@ bool MUB::FAddListCid(int32_t cid, int32_t lw0, PSTN pstn)
     or string.  If pstn is non-nil, it is used to find the item.
     If pstn is nil, lw0 is used to identify the item.
 ***************************************************************************/
-bool MUB::FRemoveListCid(int32_t cid, int32_t lw0, PSTN pstn)
+bool MUB::FRemoveListCid(int32_t cid, uintptr_t lw0, PSTN pstn)
 {
     AssertThis(0);
     AssertNilOrPo(pstn, 0);
@@ -251,7 +251,7 @@ bool MUB::FRemoveListCid(int32_t cid, int32_t lw0, PSTN pstn)
     SZ sz;
     HMENU hmenuPrev;
     int32_t dimni;
-    int32_t lw;
+    uintptr_t lw;
     bool fSeparator, fSetWcid;
     bool fRet = fTrue;
 
@@ -435,12 +435,13 @@ bool MUB::FRemoveAllListCid(int32_t cid)
     lwNew is set as the new long parameter and if pstnNew is non-nil,
     it is used as the new menu item text.
 ***************************************************************************/
-bool MUB::FChangeListCid(int32_t cid, int32_t lwOld, PSTN pstnOld, int32_t lwNew, PSTN pstnNew)
+bool MUB::FChangeListCid(int32_t cid, uintptr_t lwOld, PSTN pstnOld, uintptr_t lwNew, PSTN pstnNew)
 {
     AssertThis(0);
     AssertNilOrPo(pstnOld, 0);
     AssertNilOrPo(pstnNew, 0);
-    int32_t imlst, ilw, cch, lw;
+    int32_t imlst, ilw, cch;
+    uintptr_t lw;
     MLST mlst;
     SZ sz;
     bool fRet = fTrue;
@@ -493,7 +494,8 @@ bool MUB::_FGetCmdForWcid(int32_t wcid, PCMD pcmd)
     ClearPb(pcmd, SIZEOF(*pcmd));
     if (wcid >= wcidListBase && _FFindMlst(wcid, &mlst))
     {
-        int32_t lw, cch;
+        uintptr_t lw;
+        int32_t cch;
         SZ sz;
         STN stn;
 
@@ -506,7 +508,7 @@ bool MUB::_FGetCmdForWcid(int32_t wcid, PCMD pcmd)
         stn.GetData(pcmd->pgg->PvLock(0));
         pcmd->pgg->Unlock();
         pcmd->cid = mlst.cid;
-        pcmd->rglw[0] = lw;
+        *(uintptr_t *)pcmd->rglw = lw;
     }
     else
         pcmd->cid = wcid;
@@ -599,7 +601,7 @@ bool MUB::_FInitLists(void)
                 mlst.wcidList = wcidList;
                 wcidList += dwcidList;
                 mlst.cid = cid;
-                if (pvNil == (mlst.pgllw = GL::PglNew(SIZEOF(int32_t), vntl.OnnMac())))
+                if (pvNil == (mlst.pgllw = GL::PglNew(SIZEOF(uintptr_t), vntl.OnnMac())))
                     return fFalse;
 
                 for (onn = 0; onn < vntl.OnnMac(); onn++)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,7 +112,9 @@ target_link_libraries(studio
 
 set_property(TARGET studio PROPERTY OUTPUT_NAME 3dmovie)
 target_link_options(studio BEFORE PRIVATE $<$<LINK_LANG_AND_ID:CXX,MSVC>:/MANIFESTUAC:NO>)
-target_link_options(studio BEFORE PRIVATE "/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='x86' publicKeyToken='6595b64144ccf1df' language='*'")
+target_link_options(studio
+  BEFORE PRIVATE
+    $<$<LINK_LANG_AND_ID:CXX,MSVC>:"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'">)
 target_link_options(studio
   BEFORE PRIVATE
     $<$<AND:$<LINK_LANG_AND_ID:CXX,MSVC>,$<CONFIG:DEBUG>>:/NODEFAULTLIB:libcmt.lib>)

--- a/src/engine/modl.cpp
+++ b/src/engine/modl.cpp
@@ -308,7 +308,7 @@ LFail:
 PMODL MODL::PmodlFromBmdl(PBMDL pbmdl)
 {
     AssertVarMem(pbmdl);
-    PMODL pmodl = (PMODL) * (int32_t *)pbmdl->identifier;
+    PMODL pmodl = (PMODL) * (uintptr_t *)pbmdl->identifier;
     AssertPo(pmodl, 0);
     return pmodl;
 }
@@ -495,7 +495,7 @@ void MODL::AssertValid(uint32_t grf)
 {
     MODL_PAR::AssertValid(fobjAllocated);
     AssertVarMem(_pbmdl);
-    Assert((PMODL) * (int32_t *)_pbmdl->identifier == this, "Bad MODL identifier");
+    Assert((PMODL) * (uintptr_t *)_pbmdl->identifier == this, "Bad MODL identifier");
 }
 
 /***************************************************************************

--- a/src/engine/mtrl.cpp
+++ b/src/engine/mtrl.cpp
@@ -311,7 +311,7 @@ PMTRL MTRL::PmtrlFromBmtl(PBMTL pbmtl)
 {
     AssertVarMem(pbmtl);
 
-    PMTRL pmtrl = (PMTRL) * (int32_t *)pbmtl->identifier;
+    PMTRL pmtrl = (PMTRL) * (uintptr_t *)pbmtl->identifier;
     AssertPo(pmtrl, 0);
     return pmtrl;
 }

--- a/src/engine/scene.cpp
+++ b/src/engine/scene.cpp
@@ -4247,7 +4247,7 @@ SCEN *SCEN::PscenRead(PMVIE pmvie, PCRF pcrf, CNO cno)
                 goto LFail1;
             }
 
-            pscen->_pggsevStart->Put(isevStart, &pactr);
+            pscen->_pggsevStart->FPut(isevStart, SIZEOF(PACTR), &pactr);
             break;
 
         case sevtAddTbox:
@@ -4267,7 +4267,7 @@ SCEN *SCEN::PscenRead(PMVIE pmvie, PCRF pcrf, CNO cno)
                 goto LFail1;
             }
 
-            pscen->_pggsevStart->Put(isevStart, &ptbox);
+            pscen->_pggsevStart->FPut(isevStart, SIZEOF(PTBOX), &ptbox);
             break;
 
         case sevtSetBkgd:

--- a/src/engine/srec.cpp
+++ b/src/engine/srec.cpp
@@ -132,7 +132,7 @@ bool SREC::_FOpenRecord(void)
         }
 
         // prepare header on block of data
-        _wavehdr.dwUser = (DWORD)this;
+        _wavehdr.dwUser = (DWORD_PTR)this;
         if (waveInPrepareHeader(_hwavein, &_wavehdr, sizeof(WAVEHDR)))
         {
             waveInClose(_hwavein);

--- a/src/engine/srec.cpp
+++ b/src/engine/srec.cpp
@@ -124,7 +124,8 @@ bool SREC::_FOpenRecord(void)
     if (pvNil == _hwavein)
     {
         // open a wavein device
-        if (waveInOpen(&_hwavein, WAVE_MAPPER, _priff->PwfxGet(), (DWORD)_WaveInProc, (DWORD)this, CALLBACK_FUNCTION))
+        if (waveInOpen(&_hwavein, WAVE_MAPPER, _priff->PwfxGet(), (DWORD_PTR)_WaveInProc, (DWORD_PTR)this,
+                       CALLBACK_FUNCTION))
         {
             // it doesn't support this format
             return fFalse;

--- a/src/engine/srec.cpp
+++ b/src/engine/srec.cpp
@@ -258,7 +258,7 @@ void SREC::_UpdateStatus(void)
 /***************************************************************************
     Figure out if we're recording or not
 ***************************************************************************/
-void SREC::_WaveInProc(HWAVEIN hwi, UINT uMsg, DWORD dwInstance, DWORD dwParam1, DWORD dwParam2)
+void SREC::_WaveInProc(HWAVEIN hwi, UINT uMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2)
 {
     // the psrec pointer is a pointer to the class which generated the event and owns the device
     SREC *psrec = (SREC *)dwInstance;

--- a/src/studio/mminstal.cpp
+++ b/src/studio/mminstal.cpp
@@ -323,11 +323,11 @@ WORD wHaveMCI(PCSZ dwDeviceType)
     mciOpen.lpstrAlias = NULL;
 
     // mciErr =  mciSendCommand(0, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_TYPE_ID, (DWORD)(LPMCI_OPEN_PARMS)&mciOpen);
-    mciErr = mciSendCommand(0, MCI_OPEN, MCI_OPEN_TYPE, (DWORD)(LPMCI_OPEN_PARMS)&mciOpen);
+    mciErr = mciSendCommand(0, MCI_OPEN, MCI_OPEN_TYPE, (DWORD_PTR)(LPMCI_OPEN_PARMS)&mciOpen);
 
     if (MMSYSERR_NOERROR == mciErr)
     {
-        mciSendCommand(mciOpen.wDeviceID, MCI_CLOSE, 0, (DWORD)(LPMCI_OPEN_PARMS)&mciOpen);
+        mciSendCommand(mciOpen.wDeviceID, MCI_CLOSE, 0, (DWORD_PTR)(LPMCI_OPEN_PARMS)&mciOpen);
     }
 
 #ifdef _DEBUG

--- a/src/studio/portf.cpp
+++ b/src/studio/portf.cpp
@@ -1467,7 +1467,7 @@ LRESULT CALLBACK SubClassDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM l
         // Draw the control background in the light gray that matched the custom
         // background bitmap. Otherwise the background is drawn in the current
         // system color, which may not match the background at all.
-        return ((LONG)GetStockObject(LTGRAY_BRUSH));
+        return ((LONG_PTR)GetStockObject(LTGRAY_BRUSH));
     }
     case WM_SYSCOMMAND: {
         // Is a screen saver trying to start?

--- a/src/studio/portf.cpp
+++ b/src/studio/portf.cpp
@@ -488,13 +488,13 @@ UINT_PTR CALLBACK OpenHookProc(HWND hwndCustom, UINT msg, WPARAM wParam, LPARAM 
         lpOfn = (OPENFILENAME *)lParam;
         pdiPortfolio = (PDLGINFO)(lpOfn->lCustData);
 
-        SetWindowLong(hwndCustom, GWL_USERDATA, (LONG)pdiPortfolio);
+        SetWindowLongPtr(hwndCustom, GWLP_USERDATA, (LONG_PTR)pdiPortfolio);
 
         hwndDlg = GetParent(hwndCustom);
 
         // Give ourselves a way to access the custom dlg hwnd
         // from the common dlg subclass wndproc.
-        SetWindowLong(hwndDlg, GWL_USERDATA, (LONG)hwndCustom);
+        SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (LONG_PTR)hwndCustom);
 
         // Hide common dlg controls that we're not interested in here. Use the Common Dialog
         // Message for hiding the control. The documentation on CDM_HIDECONTROL doesn't really
@@ -562,24 +562,25 @@ UINT_PTR CALLBACK OpenHookProc(HWND hwndCustom, UINT msg, WPARAM wParam, LPARAM 
         // the window anyway..
 
         // Subclass the push btns to prevent the background flashing in the default color.
-        lpBtnProc = (WNDPROC)SetWindowLong(GetDlgItem(hwndCustom, IDC_BUTTON1), GWL_WNDPROC, (LONG)SubClassBtnProc);
+        lpBtnProc =
+            (WNDPROC)SetWindowLongPtr(GetDlgItem(hwndCustom, IDC_BUTTON1), GWLP_WNDPROC, (LONG_PTR)SubClassBtnProc);
 
         lpOtherBtnProc =
-            (WNDPROC)SetWindowLong(GetDlgItem(hwndCustom, IDC_BUTTON2), GWL_WNDPROC, (LONG)SubClassBtnProc);
+            (WNDPROC)SetWindowLongPtr(GetDlgItem(hwndCustom, IDC_BUTTON2), GWLP_WNDPROC, (LONG_PTR)SubClassBtnProc);
         Assert(lpBtnProc == lpOtherBtnProc, "Custom portfolio buttons (ok/cancel) have different window procs");
 
         lpOtherBtnProc =
-            (WNDPROC)SetWindowLong(GetDlgItem(hwndCustom, IDC_BUTTON3), GWL_WNDPROC, (LONG)SubClassBtnProc);
+            (WNDPROC)SetWindowLongPtr(GetDlgItem(hwndCustom, IDC_BUTTON3), GWLP_WNDPROC, (LONG_PTR)SubClassBtnProc);
         Assert(lpBtnProc == lpOtherBtnProc, "Custom portfolio buttons (ok/home) have different window procs");
 
         // Subclass the preview window to allow custom draw.
         lpPreviewProc =
-            (WNDPROC)SetWindowLong(GetDlgItem(hwndCustom, IDC_PREVIEW), GWL_WNDPROC, (LONG)SubClassPreviewProc);
+            (WNDPROC)SetWindowLongPtr(GetDlgItem(hwndCustom, IDC_PREVIEW), GWLP_WNDPROC, (LONG_PTR)SubClassPreviewProc);
 
         // Subclass the main common dlg window to stop static control backgrounds being
         // fill with the current system color. Instead use a color that matches our
         // custom background bitmap.
-        lpDlgProc = (WNDPROC)SetWindowLong(hwndDlg, GWL_WNDPROC, (LONG)SubClassDlgProc);
+        lpDlgProc = (WNDPROC)SetWindowLongPtr(hwndDlg, GWLP_WNDPROC, (LONG_PTR)SubClassDlgProc);
 
         // For the save portfolio we want the file name control to have focus when displayed.
         if (!pdiPortfolio->fIsOpen)

--- a/src/studio/portf.cpp
+++ b/src/studio/portf.cpp
@@ -796,7 +796,7 @@ UINT_PTR CALLBACK OpenHookProc(HWND hwndCustom, UINT msg, WPARAM wParam, LPARAM 
             // Win95 has finished doing any resizing of the custom dlg and the controls.
             // So take any special action now to ensure the portfolio still looks good.
 
-            PDLGINFO pdiPortfolio = (PDLGINFO)GetWindowLong(hwndCustom, GWL_USERDATA);
+            PDLGINFO pdiPortfolio = (PDLGINFO)GetWindowLongPtr(hwndCustom, GWLP_USERDATA);
             RCS rcsApp;
             POINT ptBtn;
             int ypBtn;
@@ -982,7 +982,7 @@ UINT_PTR CALLBACK OpenHookProc(HWND hwndCustom, UINT msg, WPARAM wParam, LPARAM 
     case WM_PAINT: {
         PDLGINFO pdiPortfolio;
 
-        pdiPortfolio = (PDLGINFO)GetWindowLong(hwndCustom, GWL_USERDATA);
+        pdiPortfolio = (PDLGINFO)GetWindowLongPtr(hwndCustom, GWLP_USERDATA);
 
         // Repaint the entire portfolio.
         RepaintPortfolio(hwndCustom);
@@ -1015,7 +1015,7 @@ void RepaintPortfolio(HWND hwndCustom)
     PAINTSTRUCT ps;
     TEXTMETRIC tmCaption;
     SZ szCaption;
-    PDLGINFO pdiPortfolio = (PDLGINFO)GetWindowLong(hwndCustom, GWL_USERDATA);
+    PDLGINFO pdiPortfolio = (PDLGINFO)GetWindowLongPtr(hwndCustom, GWLP_USERDATA);
     PMBMP pmbmp, pmbmpBtn;
     int iBtn;
     CNO cnoBack;
@@ -1217,7 +1217,7 @@ void OpenPreview(HWND hwndCustom, PGNV pgnvOff, RCS *prcsPreview)
     SZ szFile;
     ERS ersT;
     ERS *pers;
-    PDLGINFO pdiPortfolio = (PDLGINFO)GetWindowLong(hwndCustom, GWL_USERDATA);
+    PDLGINFO pdiPortfolio = (PDLGINFO)GetWindowLongPtr(hwndCustom, GWLP_USERDATA);
     bool fPreviewed = fFalse;
     RC rcPreview(*prcsPreview);
 
@@ -1487,7 +1487,7 @@ LRESULT CALLBACK SubClassDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM l
         // custom dlg now, to prevent the common dlg controls appearing before
         // the portfolio background. Note that GetDlgItem(hwndDlg, <custom dlg id>)
         // returns zero here, as the Menu part of the custom dlg is zero.
-        HWND hwndCustom = (HWND)GetWindowLong(hwndDlg, GWL_USERDATA);
+        HWND hwndCustom = (HWND)GetWindowLongPtr(hwndDlg, GWLP_USERDATA);
 
         if (hwndCustom != 0)
             UpdateWindow(hwndCustom);

--- a/src/studio/portf.cpp
+++ b/src/studio/portf.cpp
@@ -154,7 +154,7 @@ bool FPortGetFniOpen(FNI *pfni, LPCTSTR lpstrFilter, LPCTSTR lpstrTitle, FNI *pf
     diPortfolio.fDrawnBkgnd = fFalse;
     diPortfolio.grfPrevType = grfPrevType;
     diPortfolio.cnoWave = cnoWave;
-    ofn.lCustData = (DWORD)&diPortfolio;
+    ofn.lCustData = (LPARAM)&diPortfolio;
 
     ofn.lpstrFilter = lpstrFilter;
     ofn.lpstrTitle = lpstrTitle;
@@ -287,7 +287,7 @@ bool FPortGetFniSave(FNI *pfni, LPCTSTR lpstrFilter, LPCTSTR lpstrTitle, LPCTSTR
     diPortfolio.fDrawnBkgnd = fFalse;
     diPortfolio.grfPrevType = grfPrevType;
     diPortfolio.cnoWave = cnoWave;
-    ofn.lCustData = (DWORD)&diPortfolio;
+    ofn.lCustData = (LPARAM)&diPortfolio;
 
     ofn.lpstrFilter = lpstrFilter;
     ofn.lpstrTitle = lpstrTitle;


### PR DESCRIPTION
Now that the core engine is 64-bit safe and the serialisation routines are in place, all that remains is to fix up the remaining compiler warnings (along with a pointer conversion issue when reading scenes) to allow 3DMMEx to run natively as an x64 application.

In addition the final commit in the series adds an MSVC x64 build to the GitHub Action to ensure that the x64 build does not break as new changes are merged into the code.