### PR TITLE
Implement video playback for SDL builds using gstreamer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Install Packages
         run: |
           sudo apt-get update &&
-          sudo apt-get install -y g++ cmake libsdl2-dev libsdl2-ttf-dev libgtk-3-dev libfluidsynth-dev fluidsynth zenity ninja-build
+          sudo apt-get install -y g++ cmake libsdl2-dev libsdl2-ttf-dev libgtk-3-dev libfluidsynth-dev fluidsynth libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good zenity ninja-build
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: CMake Generate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ elseif("${3DMM_GUI}" STREQUAL "SDL")
 
     message(WARNING "SDL support does not work yet!")
 
+    find_package(PkgConfig)
+
     if (WIN32)
         include(FetchSDL2)
         include(FetchFluidSynth)
@@ -103,6 +105,11 @@ elseif("${3DMM_GUI}" STREQUAL "SDL")
 
     # TODO: Find libiniparser if installed
     include(FetchIniParser)
+
+    find_package(PkgConfig QUIET)
+    if (PkgConfig_FOUND)
+        pkg_check_modules(GST gstreamer-1.0 gstreamer-app-1.0)
+    endif()
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@
     * Clang (optional)
 * Linux:
   * GCC
-  * Development libraries for SDL2, SDL2_ttf, SDL2_mixer, GTK3, iconv and Fontconfig
+  * Development libraries for SDL2, SDL2_ttf, gstreamer, GTK3, iconv and Fontconfig
   * Zenity (optional: used for dialog boxes)
   * [Comic Sans MS font](https://corefonts.sourceforge.net/) (optional but strongly recommended!)
+  * gstreamer
   * Installing dependencies:
-    * Ubuntu: `sudo apt install g++ cmake ninja-build libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libgtk-3-dev libfontconfig-dev zenity`
+    * Ubuntu: `sudo apt install g++ cmake ninja-build libsdl2-dev libsdl2-ttf-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk-3-dev libfontconfig-dev zenity`
 
 ### Building
 

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -483,3 +483,353 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+gstreamer
+---------
+
+https://gitlab.freedesktop.org/gstreamer/gstreamer/
+
+License: GNU LGPL v2.1
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.

--- a/kauai/CMakeLists.txt
+++ b/kauai/CMakeLists.txt
@@ -361,6 +361,22 @@ if (3DMM_GUI STREQUAL "Win32")
         KauaiGui
         $<$<PLATFORM_ID:Windows>:Vfw32>
     )
+elseif(3DMM_GUI STREQUAL "SDL" AND GST_FOUND)
+    # Use GStreamer video player
+    add_library(KauaiVideo
+        "${PROJECT_SOURCE_DIR}/kauai/src/videosdl.cpp"
+    )
+    target_include_directories (
+        KauaiVideo
+        PUBLIC
+        "${GST_INCLUDE_DIRS}"
+    )
+    target_link_libraries(
+        KauaiVideo
+        PUBLIC
+        KauaiGui
+        "${GST_LIBRARIES}"
+    )
 else()
     message(WARNING "Video playback not implemented on GUI platform: ${3DMM_GUI}")
 

--- a/kauai/src/base.cpp
+++ b/kauai/src/base.cpp
@@ -41,7 +41,7 @@ struct DOI
 
 #define kcbBaseDebug SIZEOF(DOI)
 
-priv void _AssertDoi(DOI *pdoi, bool tLinked);
+kpriv void _AssertDoi(DOI *pdoi, bool tLinked);
 inline DOI *_PdoiFromBase(void *pv)
 {
     return (DOI *)PvSubBv(pv, kcbBaseDebug);
@@ -50,8 +50,8 @@ inline BASE *_PbaseFromDoi(DOI *pdoi)
 {
     return (BASE *)PvAddBv(pdoi, kcbBaseDebug);
 }
-priv void _LinkDoi(DOI *pdoi, DOI **ppdoiFirst);
-priv void _UnlinkDoi(DOI *pdoi);
+kpriv void _LinkDoi(DOI *pdoi, DOI **ppdoiFirst);
+kpriv void _UnlinkDoi(DOI *pdoi);
 
 DOI *_pdoiFirst;    // Head of linked list of all allocated objects.
 DOI *_pdoiFirstRaw; // Head of linked list of raw newly allocated objects.
@@ -383,7 +383,7 @@ void _AssertDoi(DOI *pdoi, bool tLinked)
 /***************************************************************************
     Link object into list.
 ***************************************************************************/
-priv void _LinkDoi(DOI *pdoi, DOI **ppdoiFirst)
+kpriv void _LinkDoi(DOI *pdoi, DOI **ppdoiFirst)
 {
     _Enter();
 
@@ -406,7 +406,7 @@ priv void _LinkDoi(DOI *pdoi, DOI **ppdoiFirst)
 /***************************************************************************
     Unlink object from list.
 ***************************************************************************/
-priv void _UnlinkDoi(DOI *pdoi)
+kpriv void _UnlinkDoi(DOI *pdoi)
 {
     _Enter();
 

--- a/kauai/src/file.cpp
+++ b/kauai/src/file.cpp
@@ -357,7 +357,7 @@ void FIL::AssertValid(uint32_t grf)
 /***************************************************************************
     Determine if the given range is within cbTot.
 ***************************************************************************/
-priv bool _FRangeIn(int32_t cbTot, int32_t cb, int32_t ib)
+kpriv bool _FRangeIn(int32_t cbTot, int32_t cb, int32_t ib)
 {
     return FIn(ib, 0, cbTot + 1) && FIn(cb, 0, cbTot - ib + 1);
 }

--- a/kauai/src/fileposix.cpp
+++ b/kauai/src/fileposix.cpp
@@ -20,7 +20,7 @@ const ulong kfpError = 0xFFFFFFFF;
     Open or create the file by calling CreateFile.  Returns hBadWin on
     failure.
 ***************************************************************************/
-priv FILE *_HfileOpen(PSZ psz, uint32_t grffil)
+kpriv FILE *_HfileOpen(PSZ psz, uint32_t grffil)
 {
     const char *mode = (grffil & ffilWriteEnable) ? "wb+" : "rb";
 

--- a/kauai/src/filewin.cpp
+++ b/kauai/src/filewin.cpp
@@ -14,13 +14,13 @@
 ASSERTNAME
 
 const uint32_t kfpError = 0xFFFFFFFF;
-priv HANDLE _HfileOpen(PSZ pszFile, bool fCreate, uint32_t grffil);
+kpriv HANDLE _HfileOpen(PSZ pszFile, bool fCreate, uint32_t grffil);
 
 /***************************************************************************
     Open or create the file by calling CreateFile.  Returns hBadWin on
     failure.
 ***************************************************************************/
-priv HANDLE _HfileOpen(PSZ psz, bool fCreate, uint32_t grffil)
+kpriv HANDLE _HfileOpen(PSZ psz, bool fCreate, uint32_t grffil)
 {
     uint32_t luAccess = GENERIC_READ;
     uint32_t luShare = 0;

--- a/kauai/src/fniposix.cpp
+++ b/kauai/src/fniposix.cpp
@@ -25,7 +25,7 @@ FTG vftgTemp = kftgTemp;
 // a long).
 const long kcchsMaxExt = SIZEOF(int32_t);
 
-priv void _CleanFtg(FTG *pftg, PSTN pstnExt = pvNil);
+kpriv void _CleanFtg(FTG *pftg, PSTN pstnExt = pvNil);
 FNI _fniTemp;
 
 RTCLASS(FNI)
@@ -745,7 +745,7 @@ bool FNI::_FChangeLeaf(PSTN pstn)
 /***************************************************************************
     Make sure the ftg is all lowercase and has no characters after a zero.
 ***************************************************************************/
-priv void _CleanFtg(FTG *pftg, PSTN pstnExt)
+kpriv void _CleanFtg(FTG *pftg, PSTN pstnExt)
 {
     AssertVarMem(pftg);
     AssertNilOrPo(pstnExt, 0);

--- a/kauai/src/fniwin.cpp
+++ b/kauai/src/fniwin.cpp
@@ -28,7 +28,7 @@ typedef OPENFILENAME OFN;
 // a long).
 const int32_t kcchsMaxExt = SIZEOF(int32_t);
 
-priv void _CleanFtg(FTG *pftg, PSTN pstnExt = pvNil);
+kpriv void _CleanFtg(FTG *pftg, PSTN pstnExt = pvNil);
 FNI _fniTemp;
 
 RTCLASS(FNI)
@@ -818,7 +818,7 @@ bool FNI::_FChangeLeaf(PSTN pstn)
 /***************************************************************************
     Make sure the ftg is all uppercase and has no characters after a zero.
 ***************************************************************************/
-priv void _CleanFtg(FTG *pftg, PSTN pstnExt)
+kpriv void _CleanFtg(FTG *pftg, PSTN pstnExt)
 {
     AssertVarMem(pftg);
     AssertNilOrPo(pstnExt, 0);

--- a/kauai/src/gfx.h
+++ b/kauai/src/gfx.h
@@ -513,6 +513,10 @@ class GNV : public GNV_PAR
     // this gross API is for AVI playback
     void DrawDib(HDRAWDIB hdd, BITMAPINFOHEADER *pbi, RC *prc);
 #endif // KAUAI_WIN32
+#ifdef KAUAI_SDL
+    // this gross API is for AVI playback
+    void DrawSurface(SDL_Surface *surface, RC *prc);
+#endif
 
     void SetPenSize(int32_t dxp, int32_t dyp);
 
@@ -795,6 +799,8 @@ class GPT : public GPT_PAR
     // Save contents of this GPT to a bitmap for debugging
     void DumpBitmap(STN *stnBmp);
 
+    // this gross API is for AVI playback
+    void DrawSurface(SDL_Surface *surface, RCS *prcs, GDD *pgdd);
 #endif // KAUAI_SDL
 #ifdef MAC
     static PGPT PgptNew(PPRT pprt, HGD hgd = hNil);

--- a/kauai/src/gfxsdl.cpp
+++ b/kauai/src/gfxsdl.cpp
@@ -18,6 +18,22 @@ const int32_t kcsdlc = 256;
 #define AssertDoSDL(x) AssertDo(0 == (x), SDL_GetError());
 
 /***************************************************************************
+    Draw a surface.
+***************************************************************************/
+void GNV::DrawSurface(SDL_Surface *surface, RC *prc)
+{
+    AssertThis(0);
+    AssertVarMem(prc);
+
+    RCS rcs;
+
+    if (!_FMapRcRcs(prc, &rcs))
+        return;
+
+    _pgpt->DrawSurface(surface, &rcs, &_gdd);
+}
+
+/***************************************************************************
     Static method to flush any pending graphics operations.
 ***************************************************************************/
 void GPT::Flush(void)
@@ -1092,6 +1108,37 @@ void GPT::Flip()
     AssertDoSDL(SDL_RenderClear(_renderer));
     AssertDoSDL(SDL_RenderCopy(_renderer, _texture, NULL, NULL));
     SDL_RenderPresent(_renderer);
+}
+
+/***************************************************************************
+    Draw the surface.
+***************************************************************************/
+void GPT::DrawSurface(SDL_Surface *surface, RCS *prcs, GDD *pgdd)
+{
+    AssertThis(0);
+    AssertVarMem(prcs);
+    AssertVarMem(pgdd);
+
+    SDL_Rect sdlRectClip = *pgdd->prcsClip;
+    SDL_SetClipRect(_surface, &sdlRectClip);
+    SDL_Rect sdlRectSrc;
+    SDL_Rect sdlRectDst;
+
+    sdlRectSrc.x = 0;
+    sdlRectSrc.y = 0;
+    sdlRectSrc.w = prcs->xpRight - prcs->xpLeft;
+    sdlRectSrc.h = prcs->ypBottom - prcs->ypTop;
+
+    sdlRectDst.x = prcs->xpLeft;
+    sdlRectDst.y = prcs->ypTop;
+    sdlRectDst.w = prcs->xpRight - prcs->xpLeft;
+    sdlRectDst.h = prcs->ypBottom - prcs->ypTop;
+
+    AssertDoSDL(SDL_BlitSurface(surface, &sdlRectSrc, _surface, &sdlRectDst));
+
+    InvalidateTexture();
+    Flip();
+    SDL_SetClipRect(_surface, pvNil);
 }
 
 #ifdef DEBUG

--- a/kauai/src/sndmastream.cpp
+++ b/kauai/src/sndmastream.cpp
@@ -19,6 +19,7 @@ MiniaudioStream::~MiniaudioStream()
     if (_fInit)
     {
         ma_sound_uninit(&_sound);
+        ma_pcm_rb_uninit(&_buffer);
         _fInit = fFalse;
     }
 

--- a/kauai/src/util.h
+++ b/kauai/src/util.h
@@ -65,9 +65,9 @@ typedef void *HPIC;
 #define BLOCK
 
 #ifdef DEBUG
-#define priv
+#define kpriv
 #else //! DEBUG
-#define priv static
+#define kpriv static
 #endif //! DEBUG
 
 // standard scalar types

--- a/kauai/src/utilmem.cpp
+++ b/kauai/src/utilmem.cpp
@@ -46,9 +46,9 @@ struct MBF
 
 MBH *_pmbhFirst; // head of the doubly linked list
 
-priv void _LinkMbh(MBH *pmbh);
-priv void _UnlinkMbh(MBH *pmbh, MBH *pmbhOld);
-priv void _AssertMbh(MBH *pmbh);
+kpriv void _LinkMbh(MBH *pmbh);
+kpriv void _UnlinkMbh(MBH *pmbh, MBH *pmbhOld);
+kpriv void _AssertMbh(MBH *pmbh);
 #endif // DEBUG
 
 #ifdef MAC
@@ -397,7 +397,7 @@ void FreePpv(void **ppv)
 /***************************************************************************
     Link the Mbh into the debug-only doubly linked list.
 ***************************************************************************/
-priv void _LinkMbh(MBH *pmbh)
+kpriv void _LinkMbh(MBH *pmbh)
 {
     AssertVarMem(pmbh);
 
@@ -418,7 +418,7 @@ priv void _LinkMbh(MBH *pmbh)
     previous value of the linked block.  pmbhOld may not be a valid pointer
     now (when mem is resized).
 ***************************************************************************/
-priv void _UnlinkMbh(MBH *pmbh, MBH *pmbhOld)
+kpriv void _UnlinkMbh(MBH *pmbh, MBH *pmbhOld)
 {
     AssertVarMem(pmbh);
     Assert(pmbhOld != pvNil, 0);

--- a/kauai/src/videosdl.cpp
+++ b/kauai/src/videosdl.cpp
@@ -1,0 +1,475 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+/***************************************************************************
+    Author: Mark Cave-Ayland
+    Project: Kauai
+
+    Graphical video implementation using gstreamer.
+
+***************************************************************************/
+
+#include "frame.h"
+#include "gfx.h"
+#include "videosdl.h"
+
+#include <thread>
+
+#include <gst/gst.h>
+#include <gst/app/gstappsink.h>
+
+#include <glib.h>
+#include <SDL2/SDL.h>
+
+ASSERTNAME
+
+RTCLASS(GVID)
+RTCLASS(GVGS)
+
+BEGIN_CMD_MAP_BASE(GVGS)
+END_CMD_MAP(&GVGS::FCmdAll, pvNil, kgrfcmmAll)
+
+const int32_t kcmhlGvgs = kswMin; // put videos at the head of the list
+
+PGVID GVID::PgvidNew(PFNI pfni, PGOB pgobBase, bool fHwndBased, int32_t hid)
+{
+    AssertPo(pfni, ffniFile);
+    AssertPo(pgobBase, 0);
+
+    return GVGS::PgvgsNew(pfni, pgobBase, hid);
+}
+
+GVID::GVID(int32_t hid) : GVID_PAR(hid)
+{
+    AssertBaseThis(0);
+}
+
+PGVGS GVGS::PgvgsNew(PFNI pfni, PGOB pgobBase, int32_t hid)
+{
+    AssertPo(pfni, ffniFile);
+    PGVGS pgvgs;
+
+    if (hid == hidNil)
+        hid = CMH::HidUnique();
+
+    if (pvNil == (pgvgs = NewObj GVGS(hid)))
+        return pvNil;
+
+    if (!pgvgs->_FInit(pfni, pgobBase))
+    {
+        ReleasePpo(&pgvgs);
+        return pvNil;
+    }
+
+    return pgvgs;
+}
+
+GVGS::GVGS(int32_t hid) : GVGS_PAR(hid)
+{
+    AssertBaseThis(0);
+}
+
+GVGS::~GVGS(void)
+{
+    AssertBaseThis(0);
+
+    if (_hth.joinable())
+    {
+        _fDone = fTrue;
+        _nscb.hevt.Set();
+        _hth.join();
+    }
+
+    if (_pastream != pvNil)
+    {
+        _pastream->FStop();
+        ReleasePpo(&_pastream);
+    }
+    if (_pgnv != pvNil)
+        ReleasePpo(&_pgnv);
+    if (_surface != NULL)
+        SDL_FreeSurface(_surface);
+
+    gst_element_set_state(_nscb.pipeline, GST_STATE_NULL);
+    gst_object_unref(_nscb.pipeline);
+}
+
+bool GVGS::_FInit(PFNI pfni, PGOB pgobBase)
+{
+    AssertPo(pfni, ffniFile);
+    AssertPo(pgobBase, 0);
+
+    STN stnPath;
+    STN stn;
+    GError *error = NULL;
+    GstSample *sample = NULL;
+    GstCaps *caps = NULL;
+    GstElement *vsink = NULL;
+    GstStructure *structure = NULL;
+    GstQuery *query = NULL;
+    g_autofree gchar *uri = NULL;
+    g_autofree gchar *desc = NULL;
+    gint64 duration;
+    gint gint_val;
+    ma_device *pdevice;
+    PGOB pgobScreen;
+    int res;
+
+    _pgobBase = pgobBase;
+    pfni->GetStnPath(&stnPath);
+
+    // Check the output format is correct
+    pdevice = MiniaudioManager::Pmanager()->Pengine()->pDevice;
+    if (pdevice->playback.format != ma_format_f32)
+    {
+        Bug("expected f32 format");
+        goto LFail;
+    }
+
+    if (pdevice->playback.channels != 2)
+    {
+        Bug("expected stereo");
+        goto LFail;
+    }
+
+    gst_init(NULL, NULL);
+
+    uri = g_uri_escape_string(stnPath.Psz(), "/", TRUE);
+    desc = g_strdup_printf("uridecodebin uri=file://%s name=u ! videoconvert ! videoscale !"
+                           " appsink name=vsink caps=\"video/x-raw,format=BGRA,pixel-aspect-ratio=1/1\""
+                           " u. ! audioconvert ! audioresample ! appsink name=asink "
+                           "caps=\"audio/x-raw,format=F32LE,rate=%d,channels=%d,layout=interleaved\"",
+                           uri, pdevice->playback.converter.sampleRateOut, pdevice->playback.channels);
+
+    _nscb.pipeline = gst_parse_launch(desc, &error);
+    if (error != NULL)
+    {
+        Bug("Unable to setup gstreamer pipeline");
+        goto LFail;
+    }
+
+    // Find width and height
+    gst_element_set_state(_nscb.pipeline, GST_STATE_PAUSED);
+    vsink = gst_bin_get_by_name(GST_BIN(_nscb.pipeline), "vsink");
+    sample = gst_app_sink_try_pull_preroll(GST_APP_SINK_CAST(vsink), 1 * GST_SECOND);
+    if (sample == NULL)
+    {
+        Bug("Unable to pre-roll");
+        goto LFail;
+    }
+    caps = gst_sample_get_caps(sample);
+    if (!caps)
+    {
+        Bug("Unable to retrieve caps");
+        goto LFail;
+    }
+    structure = gst_caps_get_structure(caps, 0);
+
+    res = gst_structure_get_int(structure, "width", &gint_val);
+    if (!res)
+    {
+        Bug("Unable to retrieve video width");
+        goto LFail;
+    }
+    _dxp = gint_val;
+    res = gst_structure_get_int(structure, "height", &gint_val);
+    if (!res)
+    {
+        Bug("Unable to retrieve video height");
+        goto LFail;
+    }
+    _dyp = gint_val;
+
+    // Determine the total number of frames in the file
+    query = gst_query_new_duration(GST_FORMAT_DEFAULT);
+    res = gst_element_query(_nscb.pipeline, query);
+    if (!res)
+    {
+        Bug("Unable to retrieve video frame count");
+        goto LFail;
+    }
+    gst_query_parse_duration(query, NULL, &duration);
+    _nfrMac = duration;
+
+    gst_clear_query(&query);
+    gst_sample_unref(sample);
+    gst_object_unref(vsink);
+
+    // Create surface
+    _surface = SDL_CreateRGBSurface(0, _dxp, _dyp, 32, 0, 0, 0, 0);
+    if (_surface == NULL)
+    {
+        Bug("Unable to create SDL surface");
+        goto LFail;
+    }
+
+    // Create the stream and start playing it
+    _pastream = MiniaudioStream::PastreamNew(MiniaudioManager::Pmanager());
+    AssertPo(_pastream, 0);
+    AssertDo(_pastream->FPlay(), "Could not play");
+
+    // Create GNV for the screen
+    pgobScreen = GOB::PgobScreen();
+    _pgnv = NewObj GNV(pgobScreen, pgobScreen->Pgpt());
+    if (_pgnv == pvNil)
+        goto LFail;
+
+    _hth = std::thread([this] { return this->_LuThread(); });
+
+    return fTrue;
+
+LFail:
+    return fFalse;
+}
+
+static void NewVideoSample(GstAppSink *vsink, NSCB *nscb)
+{
+    // Retrieve video frame and signal playback thread
+    nscb->vsample = gst_app_sink_pull_sample(vsink);
+    nscb->hevt.Set();
+}
+
+static void NewAudioSample(GstAppSink *asink, NSCB *nscb)
+{
+    // Retrieve audio frame and signal playback thread
+    nscb->asample = gst_app_sink_pull_sample(asink);
+    nscb->hevt.Set();
+}
+
+/***************************************************************************
+    AT: The video stream playback thread.
+***************************************************************************/
+uint32_t GVGS::_LuThread(void)
+{
+    AssertThis(0);
+
+    GstElement *vsink;
+    GstElement *asink;
+    GError *error = NULL;
+    bool fPlaying = false;
+
+    vsink = gst_bin_get_by_name(GST_BIN(_nscb.pipeline), "vsink");
+    g_object_set(G_OBJECT(vsink), "emit-signals", TRUE, NULL);
+    g_signal_connect(vsink, "new-sample", G_CALLBACK(NewVideoSample), &_nscb);
+    asink = gst_bin_get_by_name(GST_BIN(_nscb.pipeline), "asink");
+    g_object_set(G_OBJECT(asink), "emit-signals", TRUE, NULL);
+    g_signal_connect(asink, "new-sample", G_CALLBACK(NewAudioSample), &_nscb);
+
+    for (;;)
+    {
+        _nscb.hevt.Wait();
+
+        if (_fDone)
+            break;
+
+        _mutx.Enter();
+
+        if (_fPlaying != fPlaying)
+        {
+            if (_fPlaying == fTrue)
+                gst_element_set_state(_nscb.pipeline, GST_STATE_PLAYING);
+            else
+                gst_element_set_state(_nscb.pipeline, GST_STATE_PAUSED);
+        }
+
+        if (_fPlaying)
+        {
+            if (_nscb.vsample != NULL)
+            {
+                GstBuffer *buffer;
+                GstSample *sample;
+                GstMapInfo map;
+
+                buffer = gst_sample_get_buffer(_nscb.vsample);
+                if (gst_buffer_map(buffer, &map, GST_MAP_READ))
+                {
+                    // Update the surface with the mapped buffer and indicate
+                    // to command handler that a frame is ready to display
+                    CopyPb(map.data, _surface->pixels, _dxp * 4 * _dyp);
+                    _nscb.fFrameReady = true;
+                    gst_buffer_unmap(buffer, &map);
+                }
+                gst_sample_unref(_nscb.vsample);
+                _nscb.vsample = NULL;
+            }
+
+            if (_nscb.asample != NULL)
+            {
+                GstBuffer *buffer;
+                GstSample *sample;
+                GstMapInfo map;
+
+                buffer = gst_sample_get_buffer(_nscb.asample);
+                if (gst_buffer_map(buffer, &map, GST_MAP_READ))
+                {
+                    _pastream->FWriteAudio(map.data, map.size / (sizeof(float) * 2));
+                    gst_buffer_unmap(buffer, &map);
+                }
+                gst_sample_unref(_nscb.asample);
+                _nscb.asample = NULL;
+            }
+
+            if (gst_app_sink_is_eos(GST_APP_SINK_CAST(vsink)) && gst_app_sink_is_eos(GST_APP_SINK_CAST(asink)))
+            {
+                gst_element_set_state(_nscb.pipeline, GST_STATE_PAUSED);
+                _fPlaying = fFalse;
+            }
+        }
+
+        fPlaying = _fPlaying;
+
+        _mutx.Leave();
+    }
+
+    gst_element_set_state(_nscb.pipeline, GST_STATE_PAUSED);
+    gst_object_unref(vsink);
+    gst_object_unref(asink);
+
+    return 0;
+}
+
+int32_t GVGS::NfrMac(void)
+{
+    AssertThis(0);
+
+    return _nfrMac;
+}
+
+int32_t GVGS::NfrCur(void)
+{
+    AssertThis(0);
+
+    RawRtn();
+    return 0;
+}
+
+void GVGS::GotoNfr(int32_t nfr)
+{
+    AssertThis(0);
+    AssertIn(nfr, 0, _nfrMac);
+}
+
+bool GVGS::FPlaying(void)
+{
+    AssertThis(0);
+
+    return _fPlaying;
+}
+
+bool GVGS::FPlay(RC *prc)
+{
+    AssertThis(0);
+    AssertNilOrVarMem(prc);
+
+    Stop();
+
+    _mutx.Enter();
+    if (!vpcex->FAddCmh(this, kcmhlGvgs, kgrfcmmAll))
+        return fFalse;
+
+    SetRcPlay(prc);
+
+    _fPlaying = fTrue;
+    _mutx.Leave();
+
+    _nscb.hevt.Set();
+
+    return fTrue;
+}
+
+void GVGS::SetRcPlay(RC *prc)
+{
+    AssertThis(0);
+    AssertNilOrVarMem(prc);
+
+    if (pvNil == prc)
+        _rcPlay.Set(0, 0, _dxp, _dyp);
+    else
+        _rcPlay = *prc;
+}
+
+void GVGS::Stop(void)
+{
+    AssertThis(0);
+
+    if (!_fPlaying)
+        return;
+
+    _mutx.Enter();
+    vpcex->RemoveCmh(this, kcmhlGvgs);
+    _fPlaying = fFalse;
+    _mutx.Leave();
+
+    _nscb.hevt.Set();
+}
+
+void GVGS::Draw(PGNV pgnv, RC *prc)
+{
+    AssertThis(0);
+    AssertPo(pgnv, 0);
+    AssertVarMem(prc);
+
+    _SetRc();
+}
+
+void GVGS::_SetRc(void)
+{
+    AssertThis(0);
+    RC rcGob, rc;
+
+    _pgobBase->GetRc(&rcGob, cooHwnd);
+    rc = _rcPlay;
+    rc.Offset(rcGob.xpLeft, rcGob.ypTop);
+    if (_rc != rc || !_fVisible)
+    {
+        _fVisible = fTrue;
+        _rc = rc;
+    }
+
+    if (_cactPal != vcactRealize)
+    {
+        _cactPal = vcactRealize;
+    }
+}
+
+void GVGS::GetRc(RC *prc)
+{
+    AssertThis(0);
+    AssertVarMem(prc);
+
+    prc->Set(0, 0, _dxp, _dyp);
+}
+
+bool GVGS::FCmdAll(PCMD pcmd)
+{
+    AssertThis(0);
+    AssertVarMem(pcmd);
+
+    if (_nscb.fFrameReady == fTrue)
+    {
+        // Draw the frame in the command handler to ensure that the SDL surface
+        // is updated from the main thread (SDL is not completely thread safe)
+        _pgnv->DrawSurface(_surface, &_rc);
+        _nscb.fFrameReady = false;
+    }
+
+    return fFalse;
+}
+
+#ifdef DEBUG
+void GVGS::AssertValid(uint32_t grf)
+{
+    GVGS_PAR::AssertValid(0);
+
+    Assert(_surface != hNil, 0);
+    AssertPo(_pgobBase, 0);
+}
+
+void GVGS::MarkMem(void)
+{
+    GVGS_PAR::MarkMem();
+
+    MarkMemObj(_pastream);
+    MarkMemObj(_pgnv);
+}
+#endif // DEBUG

--- a/kauai/src/videosdl.h
+++ b/kauai/src/videosdl.h
@@ -1,0 +1,126 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+/***************************************************************************
+    Author: Mark Cave-Ayland
+    Project: Kauai
+    Copyright (c) Microsoft Corporation
+
+    Video playback for SDL.
+
+***************************************************************************/
+#ifndef VIDEO_SDL_H
+#define VIDEO_SDL_H
+
+#include <atomic>
+#include <thread>
+
+#include <gst/gst.h>
+#include <gst/app/gstappsink.h>
+
+#include <glib.h>
+#include <SDL2/SDL.h>
+
+#include "gfx.h"
+#include "sndma.h"
+#include "video.h"
+
+// New sample callback data
+typedef struct NSCB
+{
+    GstElement *pipeline = NULL;
+    Signal hevt;
+    GstSample *vsample;
+    GstSample *asample;
+    std::atomic<bool> fFrameReady = false;
+} NSCB;
+
+/****************************************
+    GStreamer video playback for SDL.
+****************************************/
+typedef class GVGS *PGVGS;
+#define GVGS_PAR GVID
+#define kclsGVGS KLCONST4('G', 'V', 'G', 'S')
+class GVGS : public GVGS_PAR
+{
+    RTCLASS_DEC
+    CMD_MAP_DEC(GVGS)
+    ASSERT
+    MARKMEM
+
+  protected:
+    int32_t _dxp;
+    int32_t _dyp;
+    RC _rc;
+    RC _rcPlay;
+    int32_t _nfrMac;
+    PGOB _pgobBase;
+    int32_t _cactPal;
+
+    std::atomic<bool> _fPlaying;
+    std::atomic<bool> _fVisible;
+    std::atomic<bool> _fDone;
+
+    MUTX _mutx;
+
+    std::thread _hth;
+    PGNV _pgnv;
+    SDL_Surface *_surface;
+
+    NSCB _nscb;
+
+    PMiniaudioStream _pastream;
+    uint32_t _LuThread(void);
+
+    GVGS(int32_t hid);
+    ~GVGS(void);
+
+    // Initialize the GVGS.
+    virtual bool _FInit(PFNI pfni, PGOB pgobBase);
+
+    // Position the hwnd associated with the video to match the GOB's position.
+    virtual void _SetRc(void);
+
+  public:
+    // Create a new video window.
+    static PGVGS PgvgsNew(PFNI pfni, PGOB pgobBase, int32_t hid = hidNil);
+
+    // Return the number of frames in the video.
+    virtual int32_t NfrMac(void) override;
+
+    // Return the current frame of the video.
+    virtual int32_t NfrCur(void) override;
+
+    /***************************************************************************
+     Advance to a particular frame.  If we are playing, stop playing.  This
+     only changes internal state and doesn't mark anything.
+     ***************************************************************************/
+    virtual void GotoNfr(int32_t nfr) override;
+
+    // Return whether or not the video is playing.
+    virtual bool FPlaying(void) override;
+
+    /***************************************************************************
+     Start playing at the current frame.  This assumes the gob is valid
+     until the video is stopped or nuked.  The gob should call this video's
+     Draw method in its Draw method.
+     ***************************************************************************/
+    virtual bool FPlay(RC *prc = pvNil) override;
+
+    // Stop playing.
+    virtual void Stop(void) override;
+
+    // Call this to draw the current state of the video image.
+    virtual void Draw(PGNV pgnv, RC *prc) override;
+
+    // Get the normal rectangle for the movie (top-left at (0, 0)).
+    virtual void GetRc(RC *prc) override;
+
+    // Set the rectangle to play into.
+    virtual void SetRcPlay(RC *prc) override;
+
+    // Intercepts all commands, so we get to play our movie no matter what.
+    virtual bool FCmdAll(PCMD pcmd);
+};
+
+#endif //! VIDEO_SDL_H


### PR DESCRIPTION
This series implements video playback for SDL builds using gstreamer, allowing the 3D Movie Maker AVI-format cut scenes to be experienced on Linux! It works by introducing a new GVGS (video gstreamer) class making use of the gstreamer appsink plugin to capture and render video frames to an SDL surface, and also direct audio frames to miniaudio.

For now the gstreamer video class is restricted to non-Windows builds, although this is something that can be implemented later if desired. However most importantly it allows everyone using 3DMMEx, regardless of OS, to meet the one and only Angus McZee!

Many thanks again to @benstone for their suggestion as how to best implement the GVGS class within the existing codebase.