### PR TITLE
Fix crash if soundfont cannot be loaded

### DIFF
--- a/kauai/src/midistreamfluidsynth.cpp
+++ b/kauai/src/midistreamfluidsynth.cpp
@@ -31,6 +31,16 @@ FMS::FMS(PFNMIDI pfn, uintptr_t luUser)
 {
     _pfnCall = pfn;
     _luUser = luUser;
+    _fOpen = fFalse;
+    _flset = pvNil;
+    _flsynth = pvNil;
+    _pastream = pvNil;
+    _fChanged = fFalse;
+    _fStop = fFalse;
+    _fDone = fFalse;
+    _pglmsb = pvNil;
+    _pmev = pvNil;
+    _pmevLim = pvNil;
     _vlmBase = kvlmFull;
 }
 
@@ -39,8 +49,6 @@ FMS::FMS(PFNMIDI pfn, uintptr_t luUser)
 ***************************************************************************/
 FMS::~FMS(void)
 {
-    int is;
-
     if (_hth.joinable())
     {
         _fDone = fTrue;
@@ -56,16 +64,30 @@ FMS::~FMS(void)
     }
 
     Assert(_fOpen == fFalse, "Still open");
-    Assert(_pglmsb->IvMac() == 0, "Still have some buffers");
-    _pastream->FStop();
-    ReleasePpo(&_pastream);
-    ReleasePpo(&_pglmsb);
+
+    if (_pastream != pvNil)
+    {
+        _pastream->FStop();
+        ReleasePpo(&_pastream);
+    }
+
+    if (_pglmsb != pvNil)
+    {
+        Assert(_pglmsb->IvMac() == 0, "Still have some buffers");
+        ReleasePpo(&_pglmsb);
+    }
 
     if (_flsynth != pvNil)
+    {
         delete_fluid_synth(_flsynth);
+        _flsynth = pvNil;
+    }
 
     if (_flset != pvNil)
+    {
         delete_fluid_settings(_flset);
+        _flset = pvNil;
+    }
 
     _fOpen = fFalse;
 
@@ -185,10 +207,16 @@ bool FMS::_FInit(void)
 
 LFail:
     if (_flsynth != pvNil)
+    {
         delete_fluid_synth(_flsynth);
+        _flsynth = pvNil;
+    }
 
     if (_flset != pvNil)
+    {
         delete_fluid_settings(_flset);
+        _flset = pvNil;
+    }
 
     _mutx.Leave();
 


### PR DESCRIPTION
If 3dmovie fails to load a fluidsynth soundfont, the FMS class destructor tries to cleanup uninitialized fields, leading to a segmentation fault.
With this PR the FMS class gets destructed cleanly and the user can continue without MIDI sound.

Log output:
```
fluidsynth: error: fluid_sfloader_load(): Failed to open '/usr/share/soundfonts/default.sf2': File does not exist.
fluidsynth: error: Unable to open file '/usr/share/soundfonts/default.sf2'
fluidsynth: error: fluid_sfloader_load(): Failed to open '/usr/share/soundfonts/default.sf2': File does not exist.
fluidsynth: error: Exception thrown in fluid_dls_font constructor
fluidsynth: error: exc: Unable to open file '/usr/share/soundfonts/default.sf2'
fluidsynth: error: Failed to load SoundFont "/usr/share/soundfonts/default.sf2"
fluidsynth: error: fluid_sfloader_load(): Failed to open '/usr/share/3dmmex/soundfont.sf3': File does not exist.
fluidsynth: error: Unable to open file '/usr/share/3dmmex/soundfont.sf3'
fluidsynth: error: fluid_sfloader_load(): Failed to open '/usr/share/3dmmex/soundfont.sf3': File does not exist.
fluidsynth: error: Exception thrown in fluid_dls_font constructor
fluidsynth: error: exc: Unable to open file '/usr/share/3dmmex/soundfont.sf3'
fluidsynth: error: Failed to load SoundFont "/usr/share/3dmmex/soundfont.sf3"
Erreur de segmentation     (core dumped)3dmovie
```

Backtrace:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fe23ecef789 in ma_node_set_state () from /usr/lib/libminiaudio.so
[Current thread is 1 (Thread 0x7fe23b9f7c80 (LWP 488851))]
(gdb) bt
#0  0x00007fe23ecef789 in ma_node_set_state () from /usr/lib/libminiaudio.so
#1  0x00007fe23ecfe7c8 in ma_sound_stop () from /usr/lib/libminiaudio.so
#2  0x00005623e5acc6cc in FMS::~FMS() ()
#3  0x00005623e5acc855 in FMS::~FMS() ()
#4  0x00005623e5ac6e36 in MDPS::_FInit() ()
#5  0x00005623e5a30391 in APPB::_FInitSound(int) ()
#6  0x00005623e5a2493b in APPB::_FInit(unsigned int, unsigned int, int) ()
#7  0x00005623e5a1f20c in APP::_FInit(unsigned int, unsigned int, int) ()
#8  0x00005623e5a212e6 in APPB::Run(unsigned int, unsigned int, int) ()
#9  0x00005623e5a1a16c in APP::Run(unsigned int, unsigned int, int) ()
#10 0x00005623e59f7eb4 in main ()
```